### PR TITLE
Add workflow to auto-close issues on PR merge to develop

### DIFF
--- a/.github/workflows/close_issues.yaml
+++ b/.github/workflows/close_issues.yaml
@@ -1,0 +1,32 @@
+name: Close Related Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Close issues from PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Extract issue numbers from PR body (Closes #X, Fixes #X, Resolves #X)
+          ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | sort -u)
+
+          if [ -z "$ISSUES" ]; then
+            echo "No issues to close"
+            exit 0
+          fi
+
+          for ISSUE in $ISSUES; do
+            echo "Closing issue #$ISSUE"
+            gh issue close $ISSUE --comment "Automatically closed by PR #${{ github.event.pull_request.number }}"
+          done


### PR DESCRIPTION
## What
Add GitHub Actions workflow to automatically close issues when PRs merge to develop.

## Why
GitHub only auto-closes issues on merges to the default branch (main). This workflow extends that functionality to develop, ensuring proper issue tracking throughout the development cycle.

## How
- Created workflow that triggers on PR merge to develop
- Parses PR description for issue references (Closes #X, Fixes #X, Resolves #X)
- Closes referenced issues automatically with proper permissions

Closes #3 