### PR TITLE
Fix Nginx Dockerfile in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: nginx
-          file: nginx/Dockerfile
+          file: nginx/Dockerfile.prod
           push: true
           tags: ${{ steps.meta-nginx.outputs.tags }}
           labels: ${{ steps.meta-nginx.outputs.labels }}


### PR DESCRIPTION
Fix a typo in the release workflow.

**Before:**
```yaml
- name: Build and push Nginx image
  uses: docker/build-push-action@v6
  with:
    context: nginx
    file: nginx/Dockerfile
````

**After:**

```yaml
- name: Build and push Nginx image
  uses: docker/build-push-action@v6
  with:
    context: nginx
    file: nginx/Dockerfile.prod
```