### PR TITLE
Fix release workflow to build frontend images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,48 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Docker metadata for Dashboard
+        id: meta-dashboard
+        uses: docker/metadata-action@v5
+        with:
+          images: anibalxyz/reconciler-prod-dashboard
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push Dashboard image
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend/dashboard
+          file: frontend/dashboard/Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta-dashboard.outputs.tags }}
+          labels: ${{ steps.meta-dashboard.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Docker metadata for Public Site
+        id: meta-public-site
+        uses: docker/metadata-action@v5
+        with:
+          images: anibalxyz/reconciler-prod-public-site
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push Public Site image
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend/public-site
+          file: frontend/public-site/Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta-public-site.outputs.tags }}
+          labels: ${{ steps.meta-public-site.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Docker metadata for Nginx
         id: meta-nginx
         uses: docker/metadata-action@v5

--- a/cli/src/reconciler_cli/modules/image.py
+++ b/cli/src/reconciler_cli/modules/image.py
@@ -23,7 +23,13 @@ BUILDABLE_SERVICES: Dict[str, List[str]] = {
 }
 
 # Services allowed to be pushed to or pulled from a registry
-REGISTRY_SERVICES = [SERVICES["API"], SERVICES["NGINX"]]
+# TODO: check if, due to the addition of dashboard and public_site here, this can be refactored
+REGISTRY_SERVICES = [
+    SERVICES["API"],
+    SERVICES["NGINX"],
+    SERVICES["DASHBOARD"],
+    SERVICES["PUBLIC_SITE"],
+]
 
 
 def get_buildable_services():


### PR DESCRIPTION
Fixes the release workflow by adding Dashboard and Public Site image builds before Nginx.

The Nginx Dockerfile.prod depends on these images as base layers, so they must be built and pushed to DockerHub first.

This fixes the release v0.1.0 workflow failure.