### PR TITLE
Fix release workflow to build base frontend image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,27 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Docker metadata for Frontend base
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: anibalxyz/reconciler-prod-frontend
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push Frontend base image
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend
+          file: frontend/Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Docker metadata for Dashboard
         id: meta-dashboard
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Fixes the release workflow by adding the base frontend image build before Dashboard and Public Site.

Dashboard and Public Site Dockerfiles depend on `anibalxyz/reconciler-prod-frontend` as their base image, so it must be built and pushed first.

This completes the fix for the release v0.1.0 workflow.