### PR TITLE
Fix frontend Dockerfile path in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: frontend
-          file: frontend/Dockerfile.prod
+          file: frontend/Dockerfile
           push: true
           tags: ${{ steps.meta-frontend.outputs.tags }}
           labels: ${{ steps.meta-frontend.outputs.labels }}


### PR DESCRIPTION
Fixes typo in release workflow: frontend uses `Dockerfile` (not `Dockerfile.prod`).