### PR TITLE
Fix release workflow by adding contents write permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create GitHub Releases
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Adds `contents: write` permission to the release workflow, required to create GitHub Releases.

Without this permission, the workflow fails with "Resource not accessible by integration" error.