### PR TITLE
feat: migrate frontend to new api responses format

### DIFF
--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthController.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthController.java
@@ -13,6 +13,8 @@ import io.javalin.http.*;
 import java.time.Clock;
 
 public class AuthController implements AuthApi {
+  // TODO: make configurable via environment
+  public static final int REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER = 2;
   public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
   private final AuthApiEnvironment env;
   private final AuthService authService;
@@ -43,7 +45,8 @@ public class AuthController implements AuthApi {
     setRefreshTokenCookie(
         ctx,
         authResultValue.refreshToken().token(),
-        authResultValue.refreshToken().secondsUntilExpiry(clock.instant()));
+        authResultValue.refreshToken().secondsUntilExpiry(clock.instant())
+            * REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER);
     ctx.status(200).json(new AuthResponse(authResultValue.accessToken()));
   }
 
@@ -77,7 +80,8 @@ public class AuthController implements AuthApi {
     setRefreshTokenCookie(
         ctx,
         authResultValue.refreshToken().token(),
-        authResultValue.refreshToken().secondsUntilExpiry(clock.instant()));
+        authResultValue.refreshToken().secondsUntilExpiry(clock.instant())
+            * REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER);
     ctx.status(200).json(new AuthResponse(authResultValue.accessToken()));
   }
 

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
@@ -1,5 +1,6 @@
 package com.anibalxyz.features.auth.api;
 
+import com.anibalxyz.features.auth.api.out.AuthErrorCode;
 import com.anibalxyz.features.auth.application.AuthService;
 import com.anibalxyz.features.auth.application.JwtService;
 import com.anibalxyz.features.auth.domain.error.AuthDomainError;
@@ -54,11 +55,11 @@ public class AuthErrorMapper implements FeatureErrorMapper {
         401,
         switch (error.getReason()) {
           case InvalidRefreshTokenError.Reason.NotFound ignored ->
-              new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Refresh token not found");
+              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
           case InvalidRefreshTokenError.Reason.Expired ignored ->
-              new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Refresh token expired");
+              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
           case InvalidRefreshTokenError.Reason.Revoked ignored ->
-              new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Refresh token revoked");
+              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         });
   }
 

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/out/AuthErrorCode.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/out/AuthErrorCode.java
@@ -1,0 +1,19 @@
+package com.anibalxyz.features.auth.api.out;
+
+import com.anibalxyz.features.common.api.out.code.ErrorCode;
+
+public enum AuthErrorCode implements ErrorCode {
+  REFRESH_TOKEN_NOT_FOUND("Refresh token not found"),
+  REFRESH_TOKEN_EXPIRED("Refresh token expired"),
+  ;
+
+  private final String title;
+
+  AuthErrorCode(String title) {
+    this.title = title;
+  }
+
+  public String title() {
+    return title;
+  }
+}

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
@@ -6,6 +6,7 @@ import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.InfrastructureErrorMapper;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
+import io.javalin.http.HandlerType;
 import io.javalin.http.HttpResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,16 @@ public class ExceptionsConfig extends RuntimeConfig {
     // Will be obsolete when fully migrated to custom exceptions.
     server.exception(HttpResponseException.class, this::handleException);
 
-    server.exception(Exception.class, this::handleException);
+    server.exception(
+        Exception.class,
+        (e, ctx) -> {
+          // Avoid interfering with CORS preflight requests; let the CORS plugin
+          // handle OPTIONS to prevent browser-side security blocks.
+          if (ctx.method().equals(HandlerType.OPTIONS)) {
+            return;
+          }
+          handleException(e, ctx);
+        });
   }
 
   private void handleException(Exception e, Context ctx) {

--- a/backend/api/src/test/java/com/anibalxyz/features/auth/api/AuthErrorMapperTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/auth/api/AuthErrorMapperTest.java
@@ -2,6 +2,7 @@ package com.anibalxyz.features.auth.api;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.anibalxyz.features.auth.api.out.AuthErrorCode;
 import com.anibalxyz.features.auth.application.AuthService;
 import com.anibalxyz.features.auth.application.JwtService;
 import com.anibalxyz.features.auth.domain.error.AuthDomainError;
@@ -144,8 +145,7 @@ public class AuthErrorMapperTest {
 
       assertThat(result.status()).isEqualTo(401);
       assertThat(result.response())
-          .isEqualTo(
-              new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Refresh token not found"));
+          .isEqualTo(new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
     }
   }
 
@@ -160,8 +160,7 @@ public class AuthErrorMapperTest {
 
       assertThat(result.status()).isEqualTo(401);
       assertThat(result.response())
-          .isEqualTo(
-              new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Refresh token not found"));
+          .isEqualTo(new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
     }
 
     @Test
@@ -171,8 +170,7 @@ public class AuthErrorMapperTest {
 
       assertThat(result.status()).isEqualTo(401);
       assertThat(result.response())
-          .isEqualTo(
-              new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Refresh token expired"));
+          .isEqualTo(new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED));
     }
 
     @Test
@@ -182,8 +180,7 @@ public class AuthErrorMapperTest {
 
       assertThat(result.status()).isEqualTo(401);
       assertThat(result.response())
-          .isEqualTo(
-              new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Refresh token revoked"));
+          .isEqualTo(new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED));
     }
   }
 

--- a/frontend/common/services/AuthService.ts
+++ b/frontend/common/services/AuthService.ts
@@ -2,9 +2,19 @@ export interface AuthResponse {
   accessToken: string;
 }
 
+export interface ErrorDetail {
+  field: string;
+  message: string;
+}
+
 export interface ErrorResponse {
-  error: string;
-  details: string[];
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  instance?: string;
+  code: string;
+  errors?: ErrorDetail[];
 }
 
 export interface UserCreateResponse {
@@ -24,8 +34,11 @@ export type ApiResponse<T> = {
 };
 
 const serverUnreachableError: ErrorResponse = {
-  error: 'Server unreachable',
-  details: ['Looks like we are having some problems :( Please try again later!'],
+  title: 'Server unreachable',
+  detail: 'Looks like we are having some problems :( Please try again later!',
+  type: '',
+  status: 500,
+  code: 'UNREACHABLE_ERROR',
 };
 
 async function performRequest<T>(request: Request): Promise<ApiResponse<T | ErrorResponse>> {

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@anibalxyz/reconciler-dashboard",
-  "version": "0.0.0",
   "private": true,
   "scripts": {
     "build": "vite build",

--- a/frontend/dashboard/src/App.tsx
+++ b/frontend/dashboard/src/App.tsx
@@ -27,32 +27,9 @@ export default function App() {
     });
   }, [authService]);
 
-  const refreshToken = useCallback(async (): Promise<number> => {
-    const response = await authService.refreshToken();
-    let responseCode = response.status;
-    if ('accessToken' in response.data) {
-      setAccessToken(response.data.accessToken);
-    } else {
-      const noSessionMessages = ['Missing refresh token in cookie', 'Refresh token not found'];
-      const expiredSessionMessages = ['Refresh token is expired or revoked'];
-
-      if (noSessionMessages.includes(response.data.details[0])) {
-        responseCode = 400;
-      } else if (expiredSessionMessages.includes(response.data.details[0])) {
-        responseCode = 401;
-      }
-    }
-    return responseCode;
-  }, [authService]);
-
-  const getModalPropsByStatus = useCallback((status: number): ModalContentProps | null => {
-    if (status < 400) {
-      return null;
-    }
-    // TODO: Frontend currently would treats all 401 from /api/auth/refresh endpoint as session expired.
-    //       It will be refined once error codes are standardized. For a while, cases will be differentiated using response details.
+  const getModalPropsByErrorCode = useCallback((status: string): ModalContentProps | null => {
     switch (status) {
-      case 400:
+      case 'UNAUTHORIZED':
         return {
           title: "It looks like you're not logged in",
           message: 'Please sign in to continue',
@@ -60,12 +37,20 @@ export default function App() {
           type: 'warn',
           redirect: '/login',
         };
-      case 401:
+      case 'REFRESH_TOKEN_EXPIRED':
         return {
           title: 'Your session has expired',
           message: 'Please sign in again',
           confirm: 'Sign in',
           type: 'info',
+          redirect: '/login',
+        };
+      case 'REFRESH_TOKEN_NOT_FOUND':
+        return {
+          title: 'Session expired or removed',
+          message: 'Please sign in again.',
+          confirm: 'Sign in',
+          type: 'warn',
           redirect: '/login',
         };
       default:
@@ -81,8 +66,17 @@ export default function App() {
 
   useEffect(() => {
     const run = async () => {
-      const status = await refreshToken();
-      setModal(getModalPropsByStatus(status));
+      const response = await authService.refreshToken();
+      let modalContent;
+
+      if ('accessToken' in response.data) {
+        setAccessToken(response.data.accessToken);
+        modalContent = null;
+      } else {
+        modalContent = getModalPropsByErrorCode(response.data.code);
+      }
+
+      setModal(modalContent);
     };
 
     // This waits until the browser finishes reloading and all cookies are reattached
@@ -96,7 +90,7 @@ export default function App() {
     return () => {
       if (!documentIsReady) window.removeEventListener('load', run);
     };
-  }, [getModalPropsByStatus, refreshToken]);
+  }, [getModalPropsByErrorCode, authService]);
 
   if (modal)
     return (
@@ -107,7 +101,7 @@ export default function App() {
 
   if (accessToken)
     return (
-      <AuthContext value={{ accessToken, refreshToken, logout }}>
+      <AuthContext value={{ accessToken, refreshToken: authService.refreshToken, logout }}>
         <Home />
       </AuthContext>
     );

--- a/frontend/dashboard/src/context/AuthContext.ts
+++ b/frontend/dashboard/src/context/AuthContext.ts
@@ -1,13 +1,14 @@
+import { ApiResponse, RefreshResponse } from '@common/services/AuthService';
 import { createContext } from 'react';
 
 interface AuthContextType {
   accessToken: string | null;
-  refreshToken: () => Promise<number>;
+  refreshToken: () => Promise<ApiResponse<RefreshResponse> | null>;
   logout: () => void;
 }
 
 export const AuthContext = createContext<AuthContextType>({
   accessToken: null,
-  refreshToken: async () => 0,
+  refreshToken: async () => null,
   logout: () => {},
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,6 @@
     },
     "dashboard": {
       "name": "@anibalxyz/reconciler-dashboard",
-      "version": "0.0.1",
       "dependencies": {
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -2380,7 +2379,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
       "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -7088,6 +7086,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8810,7 +8809,6 @@
     },
     "public-site": {
       "name": "@anibalxyz/reconciler-public-site",
-      "version": "0.0.1",
       "dependencies": {
         "astro": "5.16.5"
       },

--- a/frontend/public-site/package.json
+++ b/frontend/public-site/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@anibalxyz/reconciler-public-site",
-  "version": "0.0.0",
   "private": true,
   "scripts": {
     "build": "astro build",


### PR DESCRIPTION
## What

Migrates the frontend to consume the new RFC 9457 error response format introduced in #20. Also adds a `AuthErrorCode` enum on the backend to give the frontend the granular codes it needs to differentiate auth failure scenarios on `POST /api/auth/refresh`.

This is an initial, minimal migration: the goal was correctness and unblocking the demo deployment, not architectural improvement. A frontend clean architecture refactor is a planned follow-up task.

## Why

The backend API contract changed in PRs #20 and #21. The frontend was still reading `response.data.details[0]` and comparing against hardcoded English strings to determine which error screen to show. This was always a fragile workaround documented with a TODO:

```typescript
// TODO: Frontend currently would treats all 401 from /api/auth/refresh endpoint as session expired.
//       It will be refined once error codes are standardized.
```

The new `code` field in error responses makes this comparison explicit, stable, and language-independent. This PR replaces the string matching with code-based branching.

## How

### Frontend: ErrorResponse interface updated

The `ErrorResponse` TypeScript interface now matches the RFC 9457 structure:

```typescript
// Before
interface ErrorResponse {
  error: string;
  details: string[];
}

// After
interface ErrorResponse {
  type: string;
  title: string;
  status: number;
  detail: string;
  instance?: string;
  code: string;
  errors?: ErrorDetail[];
}
```

The fallback `serverUnreachableError` constant was updated to match.

### Frontend: error code branching in App.tsx

`getModalPropsByStatus(status: number)` was replaced by `getModalPropsByErrorCode(code: string)`, switching on `response.data.code` instead of a numeric status code derived from fragile string matching:

```typescript
// Before — fragile, English-string-dependent
const noSessionMessages = ['Missing refresh token in cookie', 'Refresh token not found'];
const expiredSessionMessages = ['Refresh token is expired or revoked'];
if (noSessionMessages.includes(response.data.details[0])) { responseCode = 400; }

// After — stable, code-based
switch (response.data.code) {
  case 'REFRESH_TOKEN_NOT_FOUND': ...
  case 'REFRESH_TOKEN_EXPIRED': ...
  case 'UNAUTHORIZED': ...
}
```

The `refreshToken` wrapper function in `App.tsx` that extracted a numeric status code was removed entirely. The component now reads the response directly and delegates to `getModalPropsByErrorCode`, simplifying the flow and removing an unnecessary layer. The `AuthContext` type was updated accordingly.

### Backend: AuthErrorCode

To support the frontend distinction between "not logged in" and "session expired", a new (and pending) `AuthErrorCode` enum was added:

```java
public enum AuthErrorCode implements ErrorCode {
  REFRESH_TOKEN_NOT_FOUND("Refresh token not found"),
  REFRESH_TOKEN_EXPIRED("Refresh token expired"),
}
```

`AuthErrorMapper` now uses these specific codes instead of `CommonErrorCode.UNAUTHORIZED`. The `Revoked` reason maps to `REFRESH_TOKEN_EXPIRED`: from the user's perspective, a revoked token and an expired token are the same outcome: the session is gone.

### Backend: CORS preflight fix

The global `Exception` handler in `ExceptionsConfig` was intercepting `OPTIONS` requests and interfering with the CORS plugin before it could respond. An early return was added for `OPTIONS` to let the CORS plugin handle preflight correctly:

```java
if (ctx.method().equals(HandlerType.OPTIONS)) {
    return;
}
```

This was discovered during swagger manual testing in `dev` environment; actually CORS is planned to be used only in development as in production the frontend will be served from the same origin as the backend.

### Backend: cookie max age multiplier

The refresh token cookie `Max-Age` is now set to `secondsUntilExpiry * 2`. The multiplier is exposed as a named constant (`REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER`) with a TODO to make it configurable via environment. The intent is to keep the cookie alive beyond the token's own expiry so the browser does not silently discard it before the server has a chance to reject it and respond with a meaningful error code.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Edge cases considered

`AuthErrorMapperTest` updated to assert against `AuthErrorCode` values instead of `CommonErrorCode.UNAUTHORIZED`. Manual testing confirmed all three refresh token error paths (`NOT_FOUND`, `EXPIRED`, `REVOKED`) render the correct modal.

## Other information

**This is a migration, not a refactor.** The frontend code was adapted to the new API contract with the minimum changes necessary. The frontend currently has no architectural pattern enforced; service calls, state management, and UI logic are intermixed. A clean architecture pass is a planned future task; it is deferred because the priority right now is getting a deployable demo out the door.

**Next steps (in order):**

1. Create a standard logging issue and implement it — this is also when `instance` in error responses gets populated
2. Update and consolidate available documentation
3. Create a centralized `docs/` directory at the repo root
4. Deploy a demo version
5. Refactor frontend architecture
6. Begin implementing MVP features