### PR TITLE
fix(ci): ensure correct exit code propagation from cli

### DIFF
--- a/backend/api/src/test/java/com/anibalxyz/features/auth/api/AuthControllerTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/auth/api/AuthControllerTest.java
@@ -129,7 +129,9 @@ public class AuthControllerTest {
       assertThat(actualCookie.getName()).isEqualTo("refreshToken");
       assertThat(actualCookie.getValue()).isEqualTo(result.refreshToken().token());
       assertThat(actualCookie.getMaxAge())
-          .isEqualTo(result.refreshToken().secondsUntilExpiry(FIXED_NOW.toInstant()));
+          .isEqualTo(
+              result.refreshToken().secondsUntilExpiry(FIXED_NOW.toInstant())
+                  * AuthController.REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER);
 
       verify(ctx).status(200);
       verify(ctx).json(expectedResponse);

--- a/cli/src/reconciler_cli/modules/compose.py
+++ b/cli/src/reconciler_cli/modules/compose.py
@@ -49,7 +49,7 @@ def compose(cmd: List[str]):
 
     run_env = os.environ.copy()
     run_env["APP_ENV"] = env
-    subprocess.run(base_cmd + cmd, env=run_env)
+    return subprocess.run(base_cmd + cmd, env=run_env)
 
 
 def get_lifecycle_services():
@@ -83,10 +83,9 @@ def run_lifecycle_command(command: List[str], services: List[str]):
         raise typer.BadParameter(f"Invalid service(s): {', '.join(invalid)}")
 
     if "all" in services:
-        compose(command)
-        return
+        return compose(command)
 
-    compose(command + services)
+    return compose(command + services)
 
 
 app = typer.Typer(
@@ -114,7 +113,9 @@ def up(
     cmd = ["up"]
     if detach:
         cmd.append("--detach")
-    run_lifecycle_command(cmd, services)
+    result = run_lifecycle_command(cmd, services)
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
 
 
 @app.command()
@@ -128,7 +129,9 @@ def down(
     ] = None,
 ):
     """Stops and removes containers and networks."""
-    run_lifecycle_command(["down", "--remove-orphans"], services)
+    result = run_lifecycle_command(["down", "--remove-orphans"], services)
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
 
 
 # TODO: make start/stop/restart/down work over running services only
@@ -143,7 +146,9 @@ def start(
     ] = None,
 ):
     """Starts existing, stopped containers."""
-    run_lifecycle_command(["start"], services)
+    result = run_lifecycle_command(["start"], services)
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
 
 
 @app.command()
@@ -157,7 +162,9 @@ def stop(
     ] = None,
 ):
     """Stops running containers without removing them."""
-    run_lifecycle_command(["stop"], services)
+    result = run_lifecycle_command(["stop"], services)
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
 
 
 @app.command()
@@ -171,7 +178,9 @@ def restart(
     ] = None,
 ):
     """Restarts running containers."""
-    run_lifecycle_command(["restart"], services)
+    result = run_lifecycle_command(["restart"], services)
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
 
 
 @app.command()
@@ -185,7 +194,9 @@ def logs(
     ] = None,
 ):
     """Follows log output for services."""
-    run_lifecycle_command(["logs", "--follow", "--tail=50"], services)
+    result = run_lifecycle_command(["logs", "--follow", "--tail=50"], services)
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
 
 
 @app.command()
@@ -264,7 +275,9 @@ def test(
         build(buildable, cache)
 
         up(["db", "flyway"])
-        up(["api"], False)
+        result = compose(["up", "--exit-code-from", "api", "api"])
+        if result.returncode != 0:
+            raise typer.Exit(code=result.returncode)
     finally:
         try:
             lifecycle = get_lifecycle_services()

--- a/cli/src/reconciler_cli/modules/image.py
+++ b/cli/src/reconciler_cli/modules/image.py
@@ -81,7 +81,7 @@ def docker(cmd_ref: List[str], service: str):
     else:
         cmd.append(f"{image}{service}")
 
-    subprocess.run(["docker"] + cmd)
+    return subprocess.run(["docker"] + cmd)
 
 
 def run_image_command(command: List[str], services: List[str]):
@@ -104,11 +104,15 @@ def run_image_command(command: List[str], services: List[str]):
     if "all" in services:
         valid_services.remove("all")
         for s in valid_services:
-            docker(command, s)
+            result = docker(command, s)
+            if result.returncode != 0:
+                raise typer.Exit(code=result.returncode)
         return
 
     for s in services:
-        docker(command, s)
+        result = docker(command, s)
+        if result.returncode != 0:
+            raise typer.Exit(code=result.returncode)
 
 
 @app.command()

--- a/cli/src/reconciler_cli/modules/resource.py
+++ b/cli/src/reconciler_cli/modules/resource.py
@@ -25,10 +25,10 @@ def execute_resource_command(verb: str, rss: str):
 
     if verb == "list":
         print(f"Listing {rss}...")
-        subprocess.run(["docker", rss[:-1], "ls"])
+        return subprocess.run(["docker", rss[:-1], "ls"])
     elif verb == "prune":
         print(f"Pruning {rss}...")
-        subprocess.run(["docker", rss[:-1], "prune", "-f"])
+        return subprocess.run(["docker", rss[:-1], "prune", "-f"])
     else:
         raise ValueError(f"Invalid verb: {verb}")
 
@@ -48,11 +48,15 @@ def prune(
     """
     if rss == "all":
         for r in DOCKER_RESOURCES:
-            execute_resource_command("prune", r)
+            result = execute_resource_command("prune", r)
+            if result.returncode != 0:
+                raise typer.Exit(code=result.returncode)
             if r != DOCKER_RESOURCES[-1]:
                 print()
     else:
-        execute_resource_command("prune", rss)
+        result = execute_resource_command("prune", rss)
+        if result.returncode != 0:
+            raise typer.Exit(code=result.returncode)
     return
 
 
@@ -71,9 +75,13 @@ def list(
     """
     if rss == "all":
         for r in DOCKER_RESOURCES:
-            execute_resource_command("list", r)
+            result = execute_resource_command("list", r)
+            if result.returncode != 0:
+                raise typer.Exit(code=result.returncode)
             if r != DOCKER_RESOURCES[-1]:
                 print()
     else:
-        execute_resource_command("list", rss)
+        result = execute_resource_command("list", rss)
+        if result.returncode != 0:
+            raise typer.Exit(code=result.returncode)
     return


### PR DESCRIPTION
## What

Fixes the CLI silently swallowing exit codes from all subprocess invocations, causing CI pipelines to report success regardless of whether Docker commands or containerized tests actually failed. Also fixes the `test` command to correctly wait for and capture the API container's result.

## Why

Every CLI command that delegates to Docker (`compose`, `docker`, `execute_resource_command`) was calling `subprocess.run` and discarding the returned `CompletedProcess` object. The return code was never evaluated, so the CLI always exited with `0`, even when the underlying process failed.

In a CI environment, this meant the pipeline would green-light a PR with a failing test suite or a container that never started. The failure was invisible at the infrastructure level.

A second, related problem was in the `test` command itself: it launched the API container with a plain `up`, which does not wait for the process to complete or expose its exit code. The test suite's result was structurally unreachable.

## How

### Exit code propagation

`compose()`, `docker()`, and `execute_resource_command()` were updated to return their `CompletedProcess` object instead of discarding it. Every call site now checks the result and raises `typer.Exit` on failure:

```python
# Before
run_lifecycle_command(["up"], services)

# After
result = run_lifecycle_command(["up"], services)
if result.returncode != 0:
    raise typer.Exit(code=result.returncode)
```

`typer.Exit(code=...)` is the idiomatic Typer way to terminate with a specific status, preserving the original exit code for the caller (CI runner, shell script, etc.) rather than flattening it to a generic error.

The fix is applied uniformly across all commands: `up`, `down`, `start`, `stop`, `restart`, `logs`, `build`, `push`, `pull`, and all `resource` subcommands (`prune`, `list`).

### Test command synchronicity

The `test` command was changed from a generic `up` call to a targeted one with `--exit-code-from`:

```python
# Before
up(["api"], False)

# After
result = compose(["up", "--exit-code-from", "api", "api"])
if result.returncode != 0:
    raise typer.Exit(code=result.returncode)
```

`--exit-code-from api` instructs Docker Compose to block until the `api` service exits and to adopt its exit code as its own. Without this flag, `docker compose up` returns as soon as all services are running (not when they finish) making the test container's outcome invisible to the process that launched it.

### Test fix (AuthControllerTest)

A failing assertion in `AuthControllerTest` was uncovered once exit codes stopped being suppressed. The test was asserting the cookie `Max-Age` against `secondsUntilExpiry` directly, but the previous PR introduced `REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER`. The assertion was updated to match:

```java
assertThat(actualCookie.getMaxAge())
    .isEqualTo(
        result.refreshToken().secondsUntilExpiry(FIXED_NOW.toInstant())
            * AuthController.REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER);
```

This test had been silently failing since the multiplier was introduced.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Edge cases considered