### PR TITLE
feat: implement structured logging foundation and request correlation

### DIFF
--- a/backend/api/Dockerfile.dev
+++ b/backend/api/Dockerfile.dev
@@ -13,4 +13,4 @@ COPY src/ ./src
 
 # TODO: there is an scenario when the api starts at the same time that db is up but migrations did not executed yet.
 #       This 3-seconds sleep **temporary** solves that. NOTE: used in dev, prod & test dockerfiles.
-ENTRYPOINT ["sh", "-c", "echo 'Waiting for DB to be ready...' && sleep 3 && exec mvn compile exec:java -Dexec.mainClass=com.anibalxyz.Main"]
+ENTRYPOINT ["sh", "-c", "echo 'Waiting for DB to be ready...' >&2 && sleep 3 && exec mvn compile -q exec:java -Dexec.mainClass=com.anibalxyz.Main"]

--- a/backend/api/Dockerfile.prod
+++ b/backend/api/Dockerfile.prod
@@ -22,4 +22,4 @@ WORKDIR /app
 
 COPY --from=build /app/target/app-jar-with-dependencies.jar app.jar
 
-ENTRYPOINT ["sh", "-c", "echo 'Waiting for DB to be ready...' && sleep 3 && exec java -jar app.jar"]
+ENTRYPOINT ["sh", "-c", "echo 'Waiting for DB to be ready...' >&2 && sleep 3 && exec java -jar app.jar"]

--- a/backend/api/Dockerfile.test
+++ b/backend/api/Dockerfile.test
@@ -10,5 +10,5 @@ COPY src ./src
 
 # The 'verify' phase compiles and runs all tests.
 # The container will execute this command, stream output, and then exit.
-# TODO: check if needs -B option (or add it dinamically)
-CMD ["sh", "-c", "echo 'Waiting for DB to be ready...' && sleep 1 && mvn verify"]
+# TODO: check if needs -B option (or add it dynamically)
+CMD ["sh", "-c", "echo 'Waiting for DB to be ready...' >&2 && sleep 1 && exec mvn verify"]

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -21,7 +21,7 @@
         <hibernate.version>7.1.0.Final</hibernate.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <logback.version>1.5.19</logback.version>
+        <logback.version>1.5.32</logback.version>
         <janino.version>3.1.12</janino.version>
         <junit.version>5.13.4</junit.version>
         <mockito.version>5.19.0</mockito.version>

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -26,7 +26,7 @@
         <janino.version>3.1.12</janino.version>
         <junit.version>5.13.4</junit.version>
         <mockito.version>5.19.0</mockito.version>
-        <assertj.version>3.27.4</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <okhttp.version>4.12.0</okhttp.version>
 
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -15,13 +15,14 @@
 
         <jetbrains.annotations.version>26.0.2</jetbrains.annotations.version>
         <postgresql.version>42.7.8</postgresql.version>
-        <jackson.version>2.18.3</jackson.version>
+        <jackson.version>2.21.3</jackson.version>
         <javalin.version>6.7.0</javalin.version>
         <jakarta-persistence.version>3.2.0</jakarta-persistence.version>
         <hibernate.version>7.1.0.Final</hibernate.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.32</logback.version>
+        <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version>
         <janino.version>3.1.12</janino.version>
         <junit.version>5.13.4</junit.version>
         <mockito.version>5.19.0</mockito.version>
@@ -227,6 +228,13 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-logback-encoder.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
@@ -1,5 +1,7 @@
 package com.anibalxyz.features.auth.api;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.anibalxyz.features.auth.api.out.AuthErrorCode;
 import com.anibalxyz.features.auth.application.AuthService;
 import com.anibalxyz.features.auth.application.JwtService;
@@ -17,10 +19,15 @@ import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.FeatureErrorMapper;
 import com.anibalxyz.server.exception.UnhandledErrorException;
 import com.anibalxyz.server.exception.UnreachableCodeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AuthErrorMapper implements FeatureErrorMapper {
 
+  private static final Logger log = LoggerFactory.getLogger(AuthErrorMapper.class);
+
   public ErrorResult mapInvalidCredentialsError() {
+    log.warn("Invalid credentials attempt");
     return new ErrorResult(
         401, new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Invalid credentials"));
   }
@@ -29,11 +36,14 @@ public class AuthErrorMapper implements FeatureErrorMapper {
     return switch (error) {
       case AuthService.AuthenticateUserError.InvalidCredentials ignored ->
           mapInvalidCredentialsError();
-      case AuthService.AuthenticateUserError.MaintenanceWindow e ->
-          new ErrorResult(
-              503,
-              new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
-                  .detail("Service unavailable until " + e.availableFrom()));
+      case AuthService.AuthenticateUserError.MaintenanceWindow e -> {
+        log.debug(
+            "Authentication during maintenance window", kv("available_from", e.availableFrom()));
+        yield new ErrorResult(
+            503,
+            new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
+                .detail("Service unavailable until " + e.availableFrom()));
+      }
       case AuthService.AuthenticateUserError.ValidationFailed e ->
           ValidationErrorMapper.map(e.notification(), ErrorMapper::mapFieldError);
     };
@@ -41,11 +51,14 @@ public class AuthErrorMapper implements FeatureErrorMapper {
 
   public ErrorResult mapRefreshTokensError(AuthService.RefreshTokensError error) {
     return switch (error) {
-      case AuthService.RefreshTokensError.MaintenanceWindow e ->
-          new ErrorResult(
-              503,
-              new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
-                  .detail("Service unavailable until " + e.availableFrom()));
+      case AuthService.RefreshTokensError.MaintenanceWindow e -> {
+        log.debug(
+            "Token refresh during maintenance window", kv("available_from", e.availableFrom()));
+        yield new ErrorResult(
+            503,
+            new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
+                .detail("Service unavailable until " + e.availableFrom()));
+      }
       case AuthService.RefreshTokensError.InvalidToken e -> mapInvalidRefreshTokenError(e.error());
     };
   }
@@ -54,12 +67,18 @@ public class AuthErrorMapper implements FeatureErrorMapper {
     return new ErrorResult(
         401,
         switch (error.getReason()) {
-          case InvalidRefreshTokenError.Reason.NotFound ignored ->
-              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
-          case InvalidRefreshTokenError.Reason.Expired ignored ->
-              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
-          case InvalidRefreshTokenError.Reason.Revoked ignored ->
-              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+          case InvalidRefreshTokenError.Reason.NotFound ignored -> {
+            log.debug("Refresh token not found");
+            yield new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+          }
+          case InvalidRefreshTokenError.Reason.Expired ignored -> {
+            log.debug("Refresh token expired");
+            yield new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+          }
+          case InvalidRefreshTokenError.Reason.Revoked ignored -> {
+            log.warn("Revoked refresh token used");
+            yield new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+          }
         });
   }
 
@@ -105,9 +124,18 @@ public class AuthErrorMapper implements FeatureErrorMapper {
     ErrorResponse base = new ErrorResponse(CommonErrorCode.UNAUTHORIZED);
     base =
         switch (jwe) {
-          case JwtService.JwtValidationError.Invalid ignored -> base.detail("Invalid JWT token");
-          case JwtService.JwtValidationError.Missing ignored -> base.detail("Missing JWT token");
-          case JwtService.JwtValidationError.Expired ignored -> base.detail("JWT has expired");
+          case JwtService.JwtValidationError.Invalid ignored -> {
+            log.warn("Invalid JWT token");
+            yield base.detail("Invalid JWT token");
+          }
+          case JwtService.JwtValidationError.Missing ignored -> {
+            log.warn("Missing JWT token");
+            yield base.detail("Missing JWT token");
+          }
+          case JwtService.JwtValidationError.Expired ignored -> {
+            log.debug("JWT has expired");
+            yield base.detail("JWT has expired");
+          }
         };
 
     return new ErrorResult(401, base);

--- a/backend/api/src/main/java/com/anibalxyz/features/users/api/UserErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/users/api/UserErrorMapper.java
@@ -1,5 +1,7 @@
 package com.anibalxyz.features.users.api;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.anibalxyz.features.common.api.ValidationErrorMapper;
 import com.anibalxyz.features.common.api.out.code.CommonErrorCode;
 import com.anibalxyz.features.common.api.out.code.ValidationErrorCode;
@@ -13,16 +15,22 @@ import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.FeatureErrorMapper;
 import com.anibalxyz.server.exception.UnhandledErrorException;
 import com.anibalxyz.server.exception.UnreachableCodeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UserErrorMapper implements FeatureErrorMapper {
+
+  private static final Logger log = LoggerFactory.getLogger(UserErrorMapper.class);
 
   public ErrorResult mapUserNotFoundError(UserNotFoundError error) {
     ErrorResponse base = new ErrorResponse(CommonErrorCode.RESOURCE_NOT_FOUND);
     return new ErrorResult(
         404,
         switch (error.getReason()) {
-          case UserNotFoundError.Reason.ById r ->
-              base.detail("User with id " + r.id() + " not found");
+          case UserNotFoundError.Reason.ById r -> {
+            log.debug("User not found", kv("user_nf_id", r.id()));
+            yield base.detail("User with id " + r.id() + " not found");
+          }
 
           case UserNotFoundError.Reason.ByEmail r ->
               throw UnreachableCodeException.of(r, "no endpoint exposes email-based user lookups");
@@ -31,11 +39,13 @@ public class UserErrorMapper implements FeatureErrorMapper {
 
   public ErrorResult mapUpdateUserByIdError(UserService.UpdateUserByIdError error) {
     return switch (error) {
-      case UserService.UpdateUserByIdError.EmptyCommand ignored ->
-          new ErrorResult(
-              400,
-              new ErrorResponse(ValidationErrorCode.VALIDATION_ERROR)
-                  .detail("At least one field (name, email, password) must be provided"));
+      case UserService.UpdateUserByIdError.EmptyCommand ignored -> {
+        log.debug("Update user with no fields provided");
+        yield new ErrorResult(
+            400,
+            new ErrorResponse(ValidationErrorCode.VALIDATION_ERROR)
+                .detail("At least one field (name, email, password) must be provided"));
+      }
       case UserService.UpdateUserByIdError.NotFound e -> mapUserNotFoundError(e.error());
       case UserService.UpdateUserByIdError.ValidationFailed e ->
           ValidationErrorMapper.map(e.notification(), this::mapFieldError);

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
@@ -10,6 +10,7 @@ import io.javalin.http.HandlerType;
 import io.javalin.http.HttpResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 // TODO: use a more semantic name for this class
 public class ExceptionsConfig extends RuntimeConfig {
@@ -27,14 +28,12 @@ public class ExceptionsConfig extends RuntimeConfig {
         FailureSignal.class,
         (e, ctx) -> {
           ErrorResult result = ErrorMapper.map(e.getError());
+          String requestId = ctx.attribute("requestId");
+          MDC.put("status", String.valueOf(result.status()));
 
-          log.debug(
-              "Failure signal received: [Status: {}] [Error: {}] [Path: {}]",
-              result.status(),
-              e.getError().getClass().getSimpleName(),
-              ctx.path());
+          // TODO: add personalized logs within mapper
 
-          ctx.status(result.status()).json(result.response());
+          ctx.status(result.status()).json(result.response().instance(requestId));
         });
 
     // Force Javalin's built-in exceptions to pass through our centralized mapper.
@@ -55,14 +54,15 @@ public class ExceptionsConfig extends RuntimeConfig {
 
   private void handleException(Exception e, Context ctx) {
     ErrorResult result = InfrastructureErrorMapper.map(e);
+    String requestId = ctx.attribute("requestId");
+    MDC.put("status", String.valueOf(result.status()));
 
     if (result.status() >= 500) {
-      log.error("Internal Server Error [Path: {}]: ", ctx.path(), e);
+      log.error("Internal Server Error: {}", e.getMessage(), e);
     } else {
-      log.debug(
-          "Client error [Status: {}] [Path: {}]: {}", result.status(), ctx.path(), e.getMessage());
+      log.debug("Client error: {}", e.getMessage());
     }
 
-    ctx.status(result.status()).json(result.response());
+    ctx.status(result.status()).json(result.response().instance(requestId));
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
@@ -31,8 +31,6 @@ public class ExceptionsConfig extends RuntimeConfig {
           String requestId = ctx.attribute("requestId");
           MDC.put("status", String.valueOf(result.status()));
 
-          // TODO: add personalized logs within mapper
-
           ctx.status(result.status()).json(result.response().instance(requestId));
         });
 
@@ -58,9 +56,9 @@ public class ExceptionsConfig extends RuntimeConfig {
     MDC.put("status", String.valueOf(result.status()));
 
     if (result.status() >= 500) {
-      log.error("Internal Server Error: {}", e.getMessage(), e);
+      log.error("{}: {}", e.getClass().getSimpleName(), e.getMessage());
     } else {
-      log.debug("Client error: {}", e.getMessage());
+      log.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage());
     }
 
     ctx.status(result.status()).json(result.response().instance(requestId));

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/LifecycleConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/LifecycleConfig.java
@@ -2,6 +2,7 @@ package com.anibalxyz.server.config.modules.runtime;
 
 import com.anibalxyz.persistence.PersistenceManager;
 import com.anibalxyz.server.context.ContextProvider;
+import com.anibalxyz.server.context.RequestContext;
 import io.javalin.Javalin;
 import jakarta.persistence.EntityManager;
 
@@ -16,6 +17,12 @@ public class LifecycleConfig extends RuntimeConfig {
   public LifecycleConfig(Javalin server, PersistenceManager persistenceManager) {
     super(server);
     this.persistenceManager = persistenceManager;
+  }
+
+  @Override
+  public void apply() {
+    setEntityManagerLifecycle();
+    setMDCLifecycle();
   }
 
   /**
@@ -52,8 +59,13 @@ public class LifecycleConfig extends RuntimeConfig {
         });
   }
 
-  @Override
-  public void apply() {
-    setEntityManagerLifecycle();
+  private void setMDCLifecycle() {
+    server.before(
+        ctx -> {
+          String requestId = RequestContext.initialize(ctx);
+          ctx.attribute("requestId", requestId);
+        });
+
+    server.after(ctx -> RequestContext.clear());
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
@@ -7,53 +7,53 @@ import org.slf4j.MDC;
 /**
  * Manages per-request contextual data via SLF4J MDC.
  *
- * <p>MDC (Mapped Diagnostic Context) is a thread-local key-value store provided by SLF4J.
- * Any value placed here is automatically included in every log statement made by any class
- * on that thread, without needing to pass it as a parameter.
+ * <p>MDC (Mapped Diagnostic Context) is a thread-local key-value store provided by SLF4J. Any value
+ * placed here is automatically included in every log statement made by any class on that thread,
+ * without needing to pass it as a parameter.
  *
- * <p>All values are cleared at the end of each request to prevent leaking into future
- * requests (thread reuse via virtual threads or thread pools).
+ * <p>All values are cleared at the end of each request to prevent leaking into future requests
+ * (thread reuse via virtual threads or thread pools).
  */
 public class RequestContext {
 
-    public static final String REQUEST_ID_KEY = "requestId";
+  public static final String REQUEST_ID_KEY = "requestId";
 
-    private RequestContext() {}
+  private RequestContext() {}
 
-    /**
-     * Generates a request ID and seeds the MDC for this request.
-     *
-     * <p>The request ID follows the format {@code req-<UUID>}.
-     *
-     * @param ctx the Javalin request context
-     * @return the request ID that was assigned
-     */
-    public static String initialize(Context ctx) {
-        String requestId = "req-" + UUID.randomUUID();
+  /**
+   * Generates a request ID and seeds the MDC for this request.
+   *
+   * <p>The request ID follows the format {@code req-<UUID>}.
+   *
+   * @param ctx the Javalin request context
+   * @return the request ID that was assigned
+   */
+  public static String initialize(Context ctx) {
+    String requestId = "req-" + UUID.randomUUID();
 
-        MDC.put(REQUEST_ID_KEY, requestId);
-        MDC.put("method", ctx.method().name());
-        MDC.put("path", ctx.path());
+    MDC.put(REQUEST_ID_KEY, requestId);
+    MDC.put("method", ctx.method().name());
+    MDC.put("path", ctx.path());
 
-        return requestId;
-    }
+    return requestId;
+  }
 
-    /**
-     * Retrieves the current request ID from the MDC.
-     *
-     * @return the request ID, or null if called outside a request context
-     */
-    public static String getCurrentRequestId() {
-        return MDC.get(REQUEST_ID_KEY);
-    }
+  /**
+   * Retrieves the current request ID from the MDC.
+   *
+   * @return the request ID, or null if called outside a request context
+   */
+  public static String getCurrentRequestId() {
+    return MDC.get(REQUEST_ID_KEY);
+  }
 
-    /**
-     * Clears all MDC values for this thread.
-     *
-     * <p>MUST be called at the end of every request to prevent stale data
-     * leaking into the next request (thread reuse).
-     */
-    public static void clear() {
-        MDC.clear();
-    }
+  /**
+   * Clears all MDC values for this thread.
+   *
+   * <p>MUST be called at the end of every request to prevent stale data leaking into the next
+   * request (thread reuse).
+   */
+  public static void clear() {
+    MDC.clear();
+  }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
@@ -1,0 +1,59 @@
+package com.anibalxyz.server.context;
+
+import io.javalin.http.Context;
+import java.util.UUID;
+import org.slf4j.MDC;
+
+/**
+ * Manages per-request contextual data via SLF4J MDC.
+ *
+ * <p>MDC (Mapped Diagnostic Context) is a thread-local key-value store provided by SLF4J.
+ * Any value placed here is automatically included in every log statement made by any class
+ * on that thread, without needing to pass it as a parameter.
+ *
+ * <p>All values are cleared at the end of each request to prevent leaking into future
+ * requests (thread reuse via virtual threads or thread pools).
+ */
+public class RequestContext {
+
+    public static final String REQUEST_ID_KEY = "requestId";
+
+    private RequestContext() {}
+
+    /**
+     * Generates a request ID and seeds the MDC for this request.
+     *
+     * <p>The request ID follows the format {@code req-<UUID>}.
+     *
+     * @param ctx the Javalin request context
+     * @return the request ID that was assigned
+     */
+    public static String initialize(Context ctx) {
+        String requestId = "req-" + UUID.randomUUID();
+
+        MDC.put(REQUEST_ID_KEY, requestId);
+        MDC.put("method", ctx.method().name());
+        MDC.put("path", ctx.path());
+
+        return requestId;
+    }
+
+    /**
+     * Retrieves the current request ID from the MDC.
+     *
+     * @return the request ID, or null if called outside a request context
+     */
+    public static String getCurrentRequestId() {
+        return MDC.get(REQUEST_ID_KEY);
+    }
+
+    /**
+     * Clears all MDC values for this thread.
+     *
+     * <p>MUST be called at the end of every request to prevent stale data
+     * leaking into the next request (thread reuse).
+     */
+    public static void clear() {
+        MDC.clear();
+    }
+}

--- a/backend/api/src/main/resources/logback.xml
+++ b/backend/api/src/main/resources/logback.xml
@@ -1,14 +1,20 @@
 <configuration>
     <property name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>requestId</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+            <includeMdcKeyName>path</includeMdcKeyName>
+            <includeMdcKeyName>method</includeMdcKeyName>
+
+            <customFields>{"service":"reconciler-api"}</customFields>
+            <timeZone>UTC</timeZone>
         </encoder>
     </appender>
 
     <root level="${LOG_LEVEL}">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="CONSOLE_JSON"/>
     </root>
 
     <logger name="io.javalin" level="INFO"/>

--- a/backend/api/src/main/resources/logback.xml
+++ b/backend/api/src/main/resources/logback.xml
@@ -3,10 +3,11 @@
 
     <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <includeMdcKeyName>requestId</includeMdcKeyName>
-            <includeMdcKeyName>userId</includeMdcKeyName>
+            <includeMdcKeyName>request_id</includeMdcKeyName>
+            <includeMdcKeyName>user_id</includeMdcKeyName>
             <includeMdcKeyName>path</includeMdcKeyName>
             <includeMdcKeyName>method</includeMdcKeyName>
+            <includeMdcKeyName>status</includeMdcKeyName>
 
             <customFields>{"service":"reconciler-api"}</customFields>
             <timeZone>UTC</timeZone>

--- a/backend/api/src/test/java/com/anibalxyz/features/auth/AuthRoutesIntegrationTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/auth/AuthRoutesIntegrationTest.java
@@ -208,7 +208,8 @@ public class AuthRoutesIntegrationTest {
       assertThat(loginResponse.code()).isEqualTo(expectedResult.status()).isEqualTo(400);
 
       ErrorResponse authResponse = http.parseBody(loginResponse, ErrorResponse.class);
-      assertThat(authResponse).isEqualTo(expectedResult.response());
+      assertThat(authResponse.instance()).isNotNull();
+      assertThat(authResponse.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -225,7 +226,8 @@ public class AuthRoutesIntegrationTest {
       assertThat(loginResponse.code()).isEqualTo(expectedResult.status()).isEqualTo(503);
 
       ErrorResponse authResponse = http.parseBody(loginResponse, ErrorResponse.class);
-      assertThat(authResponse).isEqualTo(expectedResult.response());
+      assertThat(authResponse.instance()).isNotNull();
+      assertThat(authResponse.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -243,7 +245,8 @@ public class AuthRoutesIntegrationTest {
       assertThat(loginResponse.code()).isEqualTo(expectedResult.status()).isEqualTo(401);
 
       ErrorResponse authResponse = http.parseBody(loginResponse, ErrorResponse.class);
-      assertThat(authResponse).isEqualTo(expectedResult.response());
+      assertThat(authResponse.instance()).isNotNull();
+      assertThat(authResponse.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -285,7 +288,8 @@ public class AuthRoutesIntegrationTest {
       assertThat(responseCookie).isNullOrEmpty();
 
       ErrorResponse errorResponse = http.parseBody(response, ErrorResponse.class);
-      assertThat(errorResponse).isEqualTo(expectedResult.response());
+      assertThat(errorResponse.instance()).isNotNull();
+      assertThat(errorResponse.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -306,7 +310,8 @@ public class AuthRoutesIntegrationTest {
       assertThat(responseCookie).isNullOrEmpty();
 
       ErrorResponse errorResponse = http.parseBody(response, ErrorResponse.class);
-      assertThat(errorResponse).isEqualTo(expectedResult.response());
+      assertThat(errorResponse.instance()).isNotNull();
+      assertThat(errorResponse.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -328,7 +333,8 @@ public class AuthRoutesIntegrationTest {
       assertThat(responseCookie).isNullOrEmpty();
 
       ErrorResponse errorResponse = http.parseBody(response, ErrorResponse.class);
-      assertThat(errorResponse).isEqualTo(expectedResult.response());
+      assertThat(errorResponse.instance()).isNotNull();
+      assertThat(errorResponse.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test

--- a/backend/api/src/test/java/com/anibalxyz/features/auth/JwtMiddlewareIntegrationTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/auth/JwtMiddlewareIntegrationTest.java
@@ -157,7 +157,8 @@ public class JwtMiddlewareIntegrationTest {
       ErrorResponse actualResponseBody = http.parseBody(response, ErrorResponse.class);
       // NOTE: this is fragile as we are assuming UnauthorizedResponse.message
       //       Once we use custom exception, this will be cleaner
-      assertThat(actualResponseBody).isEqualTo(expectedResult.response());
+      assertThat(actualResponseBody.instance()).isNotNull();
+      assertThat(actualResponseBody.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -170,7 +171,8 @@ public class JwtMiddlewareIntegrationTest {
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(401);
 
       ErrorResponse actualResponseBody = http.parseBody(response, ErrorResponse.class);
-      assertThat(actualResponseBody).isEqualTo(expectedResult.response());
+      assertThat(actualResponseBody.instance()).isNotNull();
+      assertThat(actualResponseBody.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -190,7 +192,8 @@ public class JwtMiddlewareIntegrationTest {
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(401);
 
       ErrorResponse actualResponseBody = http.parseBody(response, ErrorResponse.class);
-      assertThat(actualResponseBody).isEqualTo(expectedResult.response());
+      assertThat(actualResponseBody.instance()).isNotNull();
+      assertThat(actualResponseBody.instance(null)).isEqualTo(expectedResult.response());
     }
   }
 }

--- a/backend/api/src/test/java/com/anibalxyz/features/users/UsersRoutesIntegrationTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/users/UsersRoutesIntegrationTest.java
@@ -160,8 +160,10 @@ public class UsersRoutesIntegrationTest {
           };
 
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(404);
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+
+      ErrorResponse actualResponse = http.parseBody(response, ErrorResponse.class);
+      assertThat(actualResponse.instance()).isNotNull();
+      assertThat(actualResponse.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @ParameterizedTest
@@ -182,8 +184,10 @@ public class UsersRoutesIntegrationTest {
               ? http.post("/users", malformedJson)
               : http.put("/users/1", malformedJson);
       assertThat(response.code()).isEqualTo(400);
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
+      assertThat(actual.instance()).isNotNull();
+      assertThat(actual.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @ParameterizedTest
@@ -206,11 +210,12 @@ public class UsersRoutesIntegrationTest {
               : http.put("/users/1", requestBody);
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(400);
 
-      ErrorResponse actual = http.parseBody(response, new TypeReference<>() {});
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
       ErrorResponse expected = expectedResult.response();
       assertThat(actual.detail()).isEqualTo(expected.detail());
       assertThat(actual.code()).isEqualTo(expected.code());
       assertThat(actual.title()).isEqualTo(expected.title());
+      assertThat(actual.instance()).isNotNull();
       assertThat(userRepository.findAll()).isEmpty();
     }
 
@@ -224,8 +229,9 @@ public class UsersRoutesIntegrationTest {
       Response response = http.post("/users", requestBody);
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(400);
 
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
+      assertThat(actual.instance()).isNotNull();
+      assertThat(actual.instance(null)).isEqualTo(expectedResult.response());
       assertThat(userRepository.findByEmail(Email.of(requestBody.email()).getValue())).isEmpty();
     }
 
@@ -239,8 +245,9 @@ public class UsersRoutesIntegrationTest {
       Response response = http.post("/users", requestBody);
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(400);
 
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
+      assertThat(actual.instance()).isNotNull();
+      assertThat(actual.instance(null)).isEqualTo(expectedResult.response());
       assertThat(em.createQuery("SELECT COUNT(u) FROM UserEntity u", Long.class).getSingleResult())
           .isZero();
     }
@@ -258,8 +265,9 @@ public class UsersRoutesIntegrationTest {
       Response response = http.post("/users", requestBody);
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(400);
 
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
+      assertThat(actual.instance()).isNotNull();
+      assertThat(actual.instance(null)).isEqualTo(expectedResult.response());
       assertThat(userRepository.findAll()).hasSize(1);
     }
 
@@ -276,8 +284,9 @@ public class UsersRoutesIntegrationTest {
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(400);
 
       assertThat(userRepository.findById(user.id()).orElseThrow()).isEqualTo(user);
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
+      assertThat(actual.instance()).isNotNull();
+      assertThat(actual.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -295,8 +304,9 @@ public class UsersRoutesIntegrationTest {
       assertThat(400).isEqualTo(response.code()).isEqualTo(expectedResult.status());
       assertThat(userRepository.findById(userToUpdate.id()).orElseThrow().email().value())
           .isEqualTo(userToUpdate.email().value());
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
+      assertThat(actual.instance()).isNotNull();
+      assertThat(actual.instance(null)).isEqualTo(expectedResult.response());
     }
 
     @Test
@@ -310,8 +320,9 @@ public class UsersRoutesIntegrationTest {
       Response response = http.put("/users/" + user.id(), requestBody);
       assertThat(response.code()).isEqualTo(expectedResult.status()).isEqualTo(400);
 
-      assertThat(http.parseBody(response, new TypeReference<ErrorResponse>() {}))
-          .isEqualTo(expectedResult.response());
+      ErrorResponse actual = http.parseBody(response, ErrorResponse.class);
+      assertThat(actual.instance()).isNotNull();
+      assertThat(actual.instance(null)).isEqualTo(expectedResult.response());
       assertThat(userRepository.findById(user.id()).orElseThrow()).isEqualTo(user);
     }
   }


### PR DESCRIPTION
## What

Establishes the structured logging foundation for the API: JSON output via LogstashEncoder, per-request correlation IDs via MDC, `instance` field population in all error responses, and contextual logging in error mappers.

## Why

Without structured logging, production incidents require guessing; no way to trace a specific request's journey, no machine-readable fields to filter on, no correlation between an error a user sees and the log entry that explains it.

The `instance` field in RFC 9457 error responses was intentionally deferred in #20 pending a request ID mechanism. This PR implements that mechanism and closes the gap.

## How

### Structured JSON logging

`logback.xml` was migrated from a manual pattern-based appender to `LogstashEncoder`, producing JSON on stdout for all environments. MDC keys (`request_id`, `user_id`, `path`, `method`, `status`) are promoted to top-level JSON fields. A fixed `service` field identifies the source.

The dev Dockerfile was updated to redirect startup messages to `stderr` and suppress Maven's compile output (`-q`), keeping stdout exclusively for application JSON logs. This allows developers to pipe container logs directly into tools like `jq` (e.g., `docker logs -f reconciler-dev-api | jq`) without encountering parsing errors caused by non-JSON startup text.

### Correlation IDs (MDC)

`RequestContext` manages per-request MDC state. On every request:

- A `req-<UUID>` is generated and stored in MDC as `request_id`
- `method` and `path` are added to MDC
- All values are cleared in the `after()` hook (thread reuse safety)

`LifecycleConfig` wires `RequestContext.initialize()` and `RequestContext.clear()` into Javalin's before/after hooks. The request ID is also stored as a context attribute for use in response building.

### `instance` field in error responses

`ExceptionsConfig` reads the `requestId` context attribute and calls `result.response().instance(requestId)` on all error paths.

### Structured arguments in error mappers

`AuthErrorMapper` and `UserErrorMapper` now log at the appropriate level using `StructuredArguments.kv()` from `logstash-logback-encoder`, which promotes variables to top-level JSON fields rather than embedding them in the message string:

```java
// Produces: { "message": "User not found", "user_nf_id": 42, ... }
log.debug("User not found", kv("user_nf_id", r.id()));
```

Log level decisions:

- `WARN`: Invalid credentials, revoked tokens, invalid/missing JWT (security-relevant)
- `DEBUG`: Expired tokens, not found, validation failures, maintenance window (expected flows)

Infrastructure errors (Jackson-parse errors, Javalin-HTTP exceptions) are logged centrally in `ExceptionsConfig.handleException()` as `{ExceptionClass}: {message}`.

### Test updates

All integration tests updated to assert `instance` is non-null and compare responses with `instance(null)`, since the UUID is not predictable.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] Edge cases considered

Verified end-to-end: error responses contain `instance: "req-<uuid>"`, every log line for that request shares the same `request_id` field, and Docker stdout is clean JSON from first line.