### PR TITLE
feat(observability): add metrics, access logs, and structured error logging

### DIFF
--- a/backend/.env.dev.example
+++ b/backend/.env.dev.example
@@ -20,6 +20,8 @@ CONTACT_EMAIL=anibalboggioict@gmail.com
 
 # Format: IANA timezone ID (e.g., America/Montevideo, UTC, Europe/Madrid)
 SYSTEM_TIMEZONE=America/Montevideo
+# Format: ISO 8601 date-time (e.g., 2026-05-12T00:00:00Z)
+SYSTEM_TIME_OVERRIDE=
 
 # ---------------------------------------------- #
 # ==> Database Configuration                     #

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -13,7 +13,7 @@ API_PREFIX=/api
 CORS_ALLOWED_ORIGINS=
 
 # Available: TRACE, DEBUG, INFO, WARN, ERROR, OFF
-LOG_LEVEL=WARN
+LOG_LEVEL=INFO
 
 # Contact email for API documentation.
 CONTACT_EMAIL=anibalboggioict@gmail.com

--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -20,6 +20,8 @@ CONTACT_EMAIL=anibalboggioict@gmail.com
 
 # Format: IANA timezone ID (e.g., America/Montevideo, UTC, Europe/Madrid)
 SYSTEM_TIMEZONE=America/Montevideo
+# Format: ISO 8601 date-time (e.g., 2026-05-12T00:00:00Z)
+SYSTEM_TIME_OVERRIDE=
 
 # ---------------------------------------------- #
 # ==> Database Configuration                     #

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -23,6 +23,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.32</logback.version>
         <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version>
+        <micrometer-registry-prometheus.version>1.16.5</micrometer-registry-prometheus.version>
         <janino.version>3.1.12</janino.version>
         <junit.version>5.13.4</junit.version>
         <mockito.version>5.19.0</mockito.version>
@@ -234,6 +235,13 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash-logback-encoder.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer-registry-prometheus.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthController.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthController.java
@@ -11,11 +11,14 @@ import com.anibalxyz.features.common.Result;
 import com.anibalxyz.features.common.application.exception.FailureSignal;
 import io.javalin.http.*;
 import java.time.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AuthController implements AuthApi {
   // TODO: make configurable via environment
   public static final int REFRESH_TOKEN_COOKIE_MAX_AGE_MULTIPLIER = 2;
   public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+  private static final Logger log = LoggerFactory.getLogger(AuthController.class);
   private final AuthApiEnvironment env;
   private final AuthService authService;
   private final RefreshTokenService refreshTokenService;
@@ -59,6 +62,7 @@ public class AuthController implements AuthApi {
     emptyRefreshTokenCookie(ctx);
 
     ctx.status(204);
+    log.info("User logged out");
   }
 
   @Override

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
@@ -17,33 +17,32 @@ import com.anibalxyz.features.common.domain.error.InvalidValueError;
 import com.anibalxyz.server.api.ErrorMapper;
 import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.FeatureErrorMapper;
+import com.anibalxyz.server.api.LogEntry;
 import com.anibalxyz.server.exception.UnhandledErrorException;
 import com.anibalxyz.server.exception.UnreachableCodeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 public class AuthErrorMapper implements FeatureErrorMapper {
 
-  private static final Logger log = LoggerFactory.getLogger(AuthErrorMapper.class);
-
   public ErrorResult mapInvalidCredentialsError() {
-    log.warn("Invalid credentials attempt");
     return new ErrorResult(
-        401, new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Invalid credentials"));
+        401,
+        new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Invalid credentials"),
+      LogEntry.warn("Invalid credentials attempt"));
   }
 
   public ErrorResult mapAuthenticateUserError(AuthService.AuthenticateUserError error) {
     return switch (error) {
       case AuthService.AuthenticateUserError.InvalidCredentials ignored ->
           mapInvalidCredentialsError();
-      case AuthService.AuthenticateUserError.MaintenanceWindow e -> {
-        log.debug(
-            "Authentication during maintenance window", kv("available_from", e.availableFrom()));
-        yield new ErrorResult(
-            503,
-            new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
-                .detail("Service unavailable until " + e.availableFrom()));
-      }
+      case AuthService.AuthenticateUserError.MaintenanceWindow e ->
+          new ErrorResult(
+              503,
+              new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
+                  .detail("Service unavailable until " + e.availableFrom()),
+            LogEntry.debug(
+                    "Authentication during maintenance window",
+                    kv("available_from", e.availableFrom())));
       case AuthService.AuthenticateUserError.ValidationFailed e ->
           ValidationErrorMapper.map(e.notification(), ErrorMapper::mapFieldError);
     };
@@ -51,35 +50,36 @@ public class AuthErrorMapper implements FeatureErrorMapper {
 
   public ErrorResult mapRefreshTokensError(AuthService.RefreshTokensError error) {
     return switch (error) {
-      case AuthService.RefreshTokensError.MaintenanceWindow e -> {
-        log.debug(
-            "Token refresh during maintenance window", kv("available_from", e.availableFrom()));
-        yield new ErrorResult(
-            503,
-            new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
-                .detail("Service unavailable until " + e.availableFrom()));
-      }
+      case AuthService.RefreshTokensError.MaintenanceWindow e ->
+          new ErrorResult(
+              503,
+              new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
+                  .detail("Service unavailable until " + e.availableFrom()),
+            LogEntry.debug(
+                    "Token refresh during maintenance window",
+                    kv("available_from", e.availableFrom())));
       case AuthService.RefreshTokensError.InvalidToken e -> mapInvalidRefreshTokenError(e.error());
     };
   }
 
   public ErrorResult mapInvalidRefreshTokenError(InvalidRefreshTokenError error) {
-    return new ErrorResult(
-        401,
-        switch (error.getReason()) {
-          case InvalidRefreshTokenError.Reason.NotFound ignored -> {
-            log.debug("Refresh token not found");
-            yield new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
-          }
-          case InvalidRefreshTokenError.Reason.Expired ignored -> {
-            log.debug("Refresh token expired");
-            yield new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
-          }
-          case InvalidRefreshTokenError.Reason.Revoked ignored -> {
-            log.warn("Revoked refresh token used");
-            yield new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
-          }
-        });
+    return switch (error.getReason()) {
+      case InvalidRefreshTokenError.Reason.NotFound ignored ->
+          new ErrorResult(
+              401,
+              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND),
+                LogEntry.debug("Refresh token not found"));
+      case InvalidRefreshTokenError.Reason.Expired ignored ->
+          new ErrorResult(
+              401,
+              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED),
+                LogEntry.debug("Refresh token expired"));
+      case InvalidRefreshTokenError.Reason.Revoked ignored ->
+          new ErrorResult(
+              401,
+              new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED),
+                LogEntry.warn("Revoked refresh token used"));
+    };
   }
 
   @Override
@@ -122,29 +122,20 @@ public class AuthErrorMapper implements FeatureErrorMapper {
 
   public ErrorResult mapJwtValidationError(JwtService.JwtValidationError jwe) {
     ErrorResponse base = new ErrorResponse(CommonErrorCode.UNAUTHORIZED);
-    base =
-        switch (jwe) {
-          case JwtService.JwtValidationError.Invalid ignored -> {
-            log.warn("Invalid JWT token");
-            yield base.detail("Invalid JWT token");
-          }
-          case JwtService.JwtValidationError.Missing ignored -> {
-            log.warn("Missing JWT token");
-            yield base.detail("Missing JWT token");
-          }
-          case JwtService.JwtValidationError.Expired ignored -> {
-            log.debug("JWT has expired");
-            yield base.detail("JWT has expired");
-          }
-        };
-
-    return new ErrorResult(401, base);
+    return switch (jwe) {
+      case JwtService.JwtValidationError.Invalid ignored ->
+          new ErrorResult(
+              401, base.detail("Invalid JWT token"), LogEntry.warn("Invalid JWT token"));
+      case JwtService.JwtValidationError.Missing ignored ->
+          new ErrorResult(
+              401, base.detail("Missing JWT token"), LogEntry.warn("Missing JWT token"));
+      case JwtService.JwtValidationError.Expired ignored ->
+          new ErrorResult(
+              401, base.detail("JWT has expired"), LogEntry.debug("JWT has expired"));
+    };
   }
 
   public ErrorDetail mapInvalidValue(InvalidValueError error) {
-    // No switch here — InvalidRefreshTokenError is the only permitted type, and it is
-    // unreachable as a field error. If new InvalidValueError subtypes are added to
-    // AuthDomainError, this should be refactored into a switch.
     if (error instanceof InvalidRefreshTokenError e) {
       throw UnreachableCodeException.of(
           e, "refresh token errors are not field-level validation errors");

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthRoutes.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthRoutes.java
@@ -21,6 +21,6 @@ public class AuthRoutes extends RouteRegistry {
         .post("/refresh", authApi::refresh)
         .post("/logout", authApi::logout);
 
-    jwtMiddleware.register();
+    jwtMiddleware.register(); // TODO: move to a separate module
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/JwtMiddleware.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/JwtMiddleware.java
@@ -4,6 +4,7 @@ import com.anibalxyz.features.auth.application.JwtService;
 import com.anibalxyz.features.common.Result;
 import com.anibalxyz.features.common.api.Role;
 import com.anibalxyz.features.common.application.exception.FailureSignal;
+import com.anibalxyz.server.context.RequestContext;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.http.ForbiddenResponse;
@@ -66,7 +67,8 @@ public class JwtMiddleware {
       throw new FailureSignal(validationResult.getError());
     }
 
-    Integer userId = Integer.parseInt(validationResult.getValue().getSubject());
+    int userId = Integer.parseInt(validationResult.getValue().getSubject());
+    RequestContext.setUserId(userId);
     ctx.attribute(JWT_USER_ID, userId);
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/application/AuthService.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/application/AuthService.java
@@ -113,7 +113,7 @@ public class AuthService {
           new AuthenticateUserError.InvalidCredentials(new InvalidCredentialsError()));
     }
 
-      RequestContext.setUserId(user.id());
+    RequestContext.setUserId(user.id());
 
     String accessToken = jwtService.generateToken(user.id());
     RefreshToken refreshToken =
@@ -124,7 +124,6 @@ public class AuthService {
   }
 
   public Result<AuthResult, RefreshTokensError> refreshTokens(String refreshTokenString) {
-    // TODO: can refactor this 4 lines
     Optional<Instant> blocked = blockedUntil(ZonedDateTime.now(clock));
     if (blocked.isPresent()) {
       return Result.failure(new RefreshTokensError.MaintenanceWindow(blocked.get()));

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/application/AuthService.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/application/AuthService.java
@@ -19,9 +19,12 @@ import com.anibalxyz.server.context.RequestContext;
 import java.time.*;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // TODO: check if can divide this class as it is too overloaded
 public class AuthService {
+  private static final Logger log = LoggerFactory.getLogger(AuthService.class);
   private final AuthEnvironment env;
   private final Clock clock;
   private final UserService userService;
@@ -120,6 +123,7 @@ public class AuthService {
         refreshTokenService.createRefreshToken(
             user,
             calculateExpiryDate(ZonedDateTime.now(clock), env.JWT_REFRESH_EXPIRATION_TIME_DAYS()));
+    log.info("User authenticated");
     return Result.success(new AuthResult(accessToken, refreshToken));
   }
 
@@ -140,6 +144,7 @@ public class AuthService {
 
     RefreshToken newRefreshToken = rotationResult.getValue();
     String newAccessToken = jwtService.generateToken(newRefreshToken.user().id());
+    log.info("Tokens refreshed");
     return Result.success(new AuthResult(newAccessToken, newRefreshToken));
   }
 

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/application/AuthService.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/application/AuthService.java
@@ -15,6 +15,7 @@ import com.anibalxyz.features.users.domain.User;
 import com.anibalxyz.features.users.domain.error.InvalidEmailError;
 import com.anibalxyz.features.users.domain.error.InvalidPasswordError;
 import com.anibalxyz.features.users.domain.error.UserDomainError;
+import com.anibalxyz.server.context.RequestContext;
 import java.time.*;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Optional;
@@ -111,6 +112,8 @@ public class AuthService {
       return Result.failure(
           new AuthenticateUserError.InvalidCredentials(new InvalidCredentialsError()));
     }
+
+      RequestContext.setUserId(user.id());
 
     String accessToken = jwtService.generateToken(user.id());
     RefreshToken refreshToken =

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/application/RefreshTokenService.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/application/RefreshTokenService.java
@@ -8,8 +8,11 @@ import com.anibalxyz.features.users.domain.User;
 import java.time.*;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RefreshTokenService {
+  private static final Logger log = LoggerFactory.getLogger(RefreshTokenService.class);
   private final RefreshTokenRepository refreshTokenRepository;
 
   public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
@@ -55,6 +58,7 @@ public class RefreshTokenService {
     if (refreshToken.revoked()) {
       // NOTE: here could add logic to invalidate all tokens for the user
       // if a revoked token is used, as it could signal a token theft attempt.
+      log.warn("Attempted use of revoked refresh token");
       return Result.failure(InvalidRefreshTokenError.revoked());
     }
 

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/application/RefreshTokenService.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/application/RefreshTokenService.java
@@ -8,11 +8,8 @@ import com.anibalxyz.features.users.domain.User;
 import java.time.*;
 import java.util.Optional;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RefreshTokenService {
-  private static final Logger log = LoggerFactory.getLogger(RefreshTokenService.class);
   private final RefreshTokenRepository refreshTokenRepository;
 
   public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
@@ -58,7 +55,6 @@ public class RefreshTokenService {
     if (refreshToken.revoked()) {
       // NOTE: here could add logic to invalidate all tokens for the user
       // if a revoked token is used, as it could signal a token theft attempt.
-      log.warn("Attempted use of revoked refresh token");
       return Result.failure(InvalidRefreshTokenError.revoked());
     }
 

--- a/backend/api/src/main/java/com/anibalxyz/features/users/api/UserErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/users/api/UserErrorMapper.java
@@ -13,39 +13,34 @@ import com.anibalxyz.features.users.application.UserService;
 import com.anibalxyz.features.users.domain.error.*;
 import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.FeatureErrorMapper;
+import com.anibalxyz.server.api.LogEntry;
 import com.anibalxyz.server.exception.UnhandledErrorException;
 import com.anibalxyz.server.exception.UnreachableCodeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 public class UserErrorMapper implements FeatureErrorMapper {
 
-  private static final Logger log = LoggerFactory.getLogger(UserErrorMapper.class);
-
   public ErrorResult mapUserNotFoundError(UserNotFoundError error) {
     ErrorResponse base = new ErrorResponse(CommonErrorCode.RESOURCE_NOT_FOUND);
-    return new ErrorResult(
-        404,
-        switch (error.getReason()) {
-          case UserNotFoundError.Reason.ById r -> {
-            log.debug("User not found", kv("user_nf_id", r.id()));
-            yield base.detail("User with id " + r.id() + " not found");
-          }
-
-          case UserNotFoundError.Reason.ByEmail r ->
-              throw UnreachableCodeException.of(r, "no endpoint exposes email-based user lookups");
-        });
+    return switch (error.getReason()) {
+      case UserNotFoundError.Reason.ById r ->
+          new ErrorResult(
+              404,
+              base.detail("User with id " + r.id() + " not found"),
+              LogEntry.debug("User not found", kv("user_nf_id", r.id())));
+      case UserNotFoundError.Reason.ByEmail r ->
+          throw UnreachableCodeException.of(r, "no endpoint exposes email-based user lookups");
+    };
   }
 
   public ErrorResult mapUpdateUserByIdError(UserService.UpdateUserByIdError error) {
     return switch (error) {
-      case UserService.UpdateUserByIdError.EmptyCommand ignored -> {
-        log.debug("Update user with no fields provided");
-        yield new ErrorResult(
-            400,
-            new ErrorResponse(ValidationErrorCode.VALIDATION_ERROR)
-                .detail("At least one field (name, email, password) must be provided"));
-      }
+      case UserService.UpdateUserByIdError.EmptyCommand ignored ->
+          new ErrorResult(
+              400,
+              new ErrorResponse(ValidationErrorCode.VALIDATION_ERROR)
+                  .detail("At least one field (name, email, password) must be provided"),
+              LogEntry.debug("Update user with no fields provided"));
       case UserService.UpdateUserByIdError.NotFound e -> mapUserNotFoundError(e.error());
       case UserService.UpdateUserByIdError.ValidationFailed e ->
           ValidationErrorMapper.map(e.notification(), this::mapFieldError);

--- a/backend/api/src/main/java/com/anibalxyz/features/users/application/UserService.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/users/application/UserService.java
@@ -10,8 +10,11 @@ import com.anibalxyz.features.users.domain.*;
 import com.anibalxyz.features.users.domain.error.*;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UserService {
+  private static final Logger log = LoggerFactory.getLogger(UserService.class);
   private final UsersEnvironment env;
   private final UserRepository userRepository;
 
@@ -74,6 +77,7 @@ public class UserService {
       return Result.failure(notification);
     }
 
+    log.info("User created");
     return Result.success(
         userRepository.save(
             new User(nameResult.getValue(), emailResult.getValue(), passwordResult.getValue())));
@@ -129,6 +133,7 @@ public class UserService {
       return Result.failure(new UpdateUserByIdError.ValidationFailed(notification));
     }
 
+    log.info("User updated");
     return Result.success(userRepository.save(user));
   }
 
@@ -138,9 +143,11 @@ public class UserService {
    * @param id The ID of the user to delete.
    */
   public Result<Void, UserNotFoundError> deleteUserById(int id) {
-    return userRepository.deleteById(id)
-        ? Result.success(null)
-        : Result.failure(UserNotFoundError.byId(id));
+    if (userRepository.deleteById(id)) {
+      log.info("User deleted");
+      return Result.success(null);
+    }
+    return Result.failure(UserNotFoundError.byId(id));
   }
 
   public sealed interface UpdateUserByIdError {

--- a/backend/api/src/main/java/com/anibalxyz/persistence/PersistenceManager.java
+++ b/backend/api/src/main/java/com/anibalxyz/persistence/PersistenceManager.java
@@ -7,6 +7,8 @@ import org.hibernate.cfg.HikariCPSettings;
 import org.hibernate.hikaricp.internal.HikariCPConnectionProvider;
 import org.hibernate.jpa.HibernatePersistenceConfiguration;
 import org.hibernate.tool.schema.Action;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manages the lifecycle of the JPA {@link EntityManagerFactory}.
@@ -16,12 +18,15 @@ import org.hibernate.tool.schema.Action;
  * provides a graceful shutdown mechanism.
  */
 public class PersistenceManager {
+  private static final Logger log = LoggerFactory.getLogger(PersistenceManager.class);
   private final EntityManagerFactory emf;
   private final DatabaseVariables dbConfig;
 
   public PersistenceManager(DatabaseVariables dbConfig) {
     this.dbConfig = dbConfig;
+    log.info("Initializing database connection pool: {}", dbConfig);
     emf = getProperties().createEntityManagerFactory();
+    log.info("Database connection pool initialized successfully");
   }
 
   public EntityManagerFactory emf() {

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -7,10 +7,7 @@ import com.anibalxyz.persistence.PersistenceManager;
 import com.anibalxyz.server.config.AppEnv;
 import com.anibalxyz.server.config.environment.AppEnvironmentSource;
 import com.anibalxyz.server.config.environment.ApplicationConfiguration;
-import com.anibalxyz.server.config.modules.runtime.ExceptionsConfig;
-import com.anibalxyz.server.config.modules.runtime.LifecycleConfig;
-import com.anibalxyz.server.config.modules.runtime.MetricsConfig;
-import com.anibalxyz.server.config.modules.runtime.SchedulerConfig;
+import com.anibalxyz.server.config.modules.runtime.*;
 import com.anibalxyz.server.config.modules.startup.ServerConfig;
 import com.anibalxyz.server.config.modules.startup.SwaggerConfig;
 import com.anibalxyz.server.context.JavalinContextEntityManagerProvider;
@@ -141,6 +138,7 @@ public class Application {
             clock);
 
     new LifecycleConfig(server, persistenceManager).apply();
+    new AccessLogConfig(server).apply();
     new MetricsConfig(server).apply();
     new ExceptionsConfig(server).apply();
     // TODO: Refactor request lifecycle management.

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -181,7 +181,9 @@ public class Application {
   public void start(int port) {
     log.info("Starting server on port {} [{} mode]", port, config.env().APP_ENV());
     javalin.start(port);
-    log.info("Server started successfully and is ready to accept connections on {}", kv("api_url", config.env().API_URL()));
+    log.info(
+        "Server started successfully and is ready to accept connections on {}",
+        kv("api_url", config.env().API_URL()));
   }
 
   /** Stops the web server and shuts down the persistence layer gracefully. */

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -1,5 +1,7 @@
 package com.anibalxyz.server;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.anibalxyz.features.auth.api.AuthRoutes;
 import com.anibalxyz.features.system.api.SystemRoutes;
 import com.anibalxyz.features.users.api.UserRoutes;
@@ -179,7 +181,7 @@ public class Application {
   public void start(int port) {
     log.info("Starting server on port {} [{} mode]", port, config.env().APP_ENV());
     javalin.start(port);
-    log.info("Server started successfully and is ready to accept connections");
+    log.info("Server started successfully and is ready to accept connections on {}", kv("api_url", config.env().API_URL()));
   }
 
   /** Stops the web server and shuts down the persistence layer gracefully. */

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -9,6 +9,7 @@ import com.anibalxyz.server.config.environment.AppEnvironmentSource;
 import com.anibalxyz.server.config.environment.ApplicationConfiguration;
 import com.anibalxyz.server.config.modules.runtime.ExceptionsConfig;
 import com.anibalxyz.server.config.modules.runtime.LifecycleConfig;
+import com.anibalxyz.server.config.modules.runtime.MetricsConfig;
 import com.anibalxyz.server.config.modules.runtime.SchedulerConfig;
 import com.anibalxyz.server.config.modules.startup.ServerConfig;
 import com.anibalxyz.server.config.modules.startup.SwaggerConfig;
@@ -140,6 +141,7 @@ public class Application {
             clock);
 
     new LifecycleConfig(server, persistenceManager).apply();
+    new MetricsConfig(server).apply();
     new ExceptionsConfig(server).apply();
     // TODO: Refactor request lifecycle management.
     //       Current temporal fix: RequestContext.clear() is moved here to ensure it's the absolute

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -17,6 +17,8 @@ import io.javalin.config.JavalinConfig;
 import java.time.Clock;
 import java.time.ZoneId;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The main application class, acting as the Composition Root.
@@ -27,6 +29,7 @@ import java.util.function.Consumer;
  * instance tailored for different environments (e.g., test, development).
  */
 public class Application {
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
   private final Javalin javalin;
   private final PersistenceManager persistenceManager;
   private final ApplicationConfiguration config;
@@ -174,7 +177,9 @@ public class Application {
    * @param port The port to listen on.
    */
   public void start(int port) {
+    log.info("Starting server on port {} [{} mode]", port, config.env().APP_ENV());
     javalin.start(port);
+    log.info("Server started successfully and is ready to accept connections");
   }
 
   /** Stops the web server and shuts down the persistence layer gracefully. */

--- a/backend/api/src/main/java/com/anibalxyz/server/api/ErrorResult.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/api/ErrorResult.java
@@ -2,4 +2,9 @@ package com.anibalxyz.server.api;
 
 import com.anibalxyz.features.common.api.out.response.error.ErrorResponse;
 
-public record ErrorResult(int status, ErrorResponse response) {}
+public record ErrorResult(int status, ErrorResponse response, LogEntry logEntry) {
+
+  public ErrorResult(int status, ErrorResponse response) {
+    this(status, response, null);
+  }
+}

--- a/backend/api/src/main/java/com/anibalxyz/server/api/LogEntry.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/api/LogEntry.java
@@ -1,0 +1,35 @@
+package com.anibalxyz.server.api;
+
+import org.slf4j.event.Level;
+
+public class LogEntry {
+  private final Level level;
+  private final String message;
+  private final Object[] args;
+
+  private LogEntry(Level level, String message, Object... args) {
+    this.level = level;
+    this.message = message;
+    this.args = args;
+  }
+
+  public static LogEntry warn(String message, Object... args) {
+    return new LogEntry(Level.WARN, message, args);
+  }
+
+  public static LogEntry debug(String message, Object... args) {
+    return new LogEntry(Level.DEBUG, message, args);
+  }
+
+  public Level level() {
+    return level;
+  }
+
+  public String message() {
+    return message;
+  }
+
+  public Object[] args() {
+    return args;
+  }
+}

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
@@ -10,6 +10,7 @@ import io.javalin.http.SameSite;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Arrays;
 import javax.crypto.SecretKey;
 
 /**
@@ -41,5 +42,17 @@ public record AppEnvironmentSource(
         ServerEnvironment,
         JwtEnvironment,
         AuthApiEnvironment,
-        AuthEnvironment {}
-  // TODO: implement toString() method to output a prettier string and to hide sensitive data
+        AuthEnvironment {
+  @Override
+  public String toString() {
+    return "AppEnvironmentSource["
+        + "APP_ENV=" + APP_ENV
+        + ", API_PORT=" + API_PORT
+        + ", API_URL=" + API_URL
+        + ", CORS_ALLOWED_ORIGINS=" + Arrays.toString(CORS_ALLOWED_ORIGINS)
+        + ", JWT_KEY=******"
+        + ", JWT_ISSUER=" + JWT_ISSUER
+        + ", BCRYPT_LOG_ROUNDS=" + BCRYPT_LOG_ROUNDS
+        + "]";
+  }
+}

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Single source of truth for application configuration.
@@ -44,15 +45,21 @@ public record AppEnvironmentSource(
         AuthApiEnvironment,
         AuthEnvironment {
   @Override
-  public String toString() {
+  public @NonNull String toString() {
     return "AppEnvironmentSource["
-        + "APP_ENV=" + APP_ENV
-        + ", API_PORT=" + API_PORT
-        + ", API_URL=" + API_URL
-        + ", CORS_ALLOWED_ORIGINS=" + Arrays.toString(CORS_ALLOWED_ORIGINS)
+        + "APP_ENV="
+        + APP_ENV
+        + ", API_PORT="
+        + API_PORT
+        + ", API_URL="
+        + API_URL
+        + ", CORS_ALLOWED_ORIGINS="
+        + Arrays.toString(CORS_ALLOWED_ORIGINS)
         + ", JWT_KEY=******"
-        + ", JWT_ISSUER=" + JWT_ISSUER
-        + ", BCRYPT_LOG_ROUNDS=" + BCRYPT_LOG_ROUNDS
+        + ", JWT_ISSUER="
+        + JWT_ISSUER
+        + ", BCRYPT_LOG_ROUNDS="
+        + BCRYPT_LOG_ROUNDS
         + "]";
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/ApplicationConfiguration.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/ApplicationConfiguration.java
@@ -1,6 +1,41 @@
 package com.anibalxyz.server.config.environment;
 
 import com.anibalxyz.persistence.DatabaseVariables;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-/** Simple wrapper for configuration properties that are loaded at startup. */
-public record ApplicationConfiguration(AppEnvironmentSource env, DatabaseVariables database) {}
+public record ApplicationConfiguration(AppEnvironmentSource env, DatabaseVariables database) {
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> configSummary = new LinkedHashMap<>();
+    configSummary.put("environment", env.APP_ENV());
+
+    Map<String, Object> api = new LinkedHashMap<>();
+    api.put("url", env.API_URL());
+    api.put("port", env.API_PORT());
+    api.put("prefix", env.API_PREFIX());
+    api.put("corsOrigins", env.CORS_ALLOWED_ORIGINS());
+    configSummary.put("api", api);
+
+    Map<String, Object> databaseMap = new LinkedHashMap<>();
+    databaseMap.put("url", database.url());
+    databaseMap.put("user", database.user());
+    configSummary.put("database", databaseMap);
+
+    Map<String, Object> jwt = new LinkedHashMap<>();
+    jwt.put("issuer", env.JWT_ISSUER());
+    jwt.put("accessTokenExpirationMinutes", env.JWT_ACCESS_EXPIRATION_TIME_MINUTES());
+    jwt.put("refreshTokenExpirationDays", env.JWT_REFRESH_EXPIRATION_TIME_DAYS().toDays());
+    configSummary.put("jwt", jwt);
+
+    Map<String, Object> auth = new LinkedHashMap<>();
+    auth.put("bcryptLogRounds", env.BCRYPT_LOG_ROUNDS());
+    auth.put("cookieSecure", env.AUTH_COOKIE_SECURE());
+    auth.put("cookieDomain", env.AUTH_COOKIE_DOMAIN());
+    auth.put("cookieSameSite", env.AUTH_COOKIE_SAMESITE());
+    auth.put("cookiePath", env.AUTH_COOKIE_PATH());
+    configSummary.put("auth", auth);
+
+    return configSummary;
+  }
+}

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
@@ -1,5 +1,7 @@
 package com.anibalxyz.server.config.environment;
 
+import static net.logstash.logback.argument.StructuredArguments.v;
+
 import com.anibalxyz.persistence.DatabaseVariables;
 import com.anibalxyz.server.config.AppEnv;
 import io.javalin.http.SameSite;
@@ -11,11 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import static net.logstash.logback.argument.StructuredArguments.v;
-
 import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
@@ -210,36 +208,7 @@ public class ConfigurationFactory {
         new ApplicationConfiguration(
             env, DatabaseVariables.generate(dbHost, dbPort, dbName, dbUser, dbPassword));
 
-    Map<String, Object> configSummary = new LinkedHashMap<>();
-    configSummary.put("environment", env.APP_ENV());
-
-    Map<String, Object> api = new LinkedHashMap<>();
-    api.put("url", env.API_URL());
-    api.put("port", env.API_PORT());
-    api.put("prefix", env.API_PREFIX());
-    api.put("corsOriginsCount", env.CORS_ALLOWED_ORIGINS().length);
-    configSummary.put("api", api);
-
-    Map<String, Object> database = new LinkedHashMap<>();
-    database.put("url", result.database().url());
-    database.put("user", result.database().user());
-    configSummary.put("database", database);
-
-    Map<String, Object> jwt = new LinkedHashMap<>();
-    jwt.put("issuer", env.JWT_ISSUER());
-    jwt.put("accessTokenExpirationMinutes", env.JWT_ACCESS_EXPIRATION_TIME_MINUTES());
-    jwt.put("refreshTokenExpirationDays", env.JWT_REFRESH_EXPIRATION_TIME_DAYS().toDays());
-    configSummary.put("jwt", jwt);
-
-    Map<String, Object> auth = new LinkedHashMap<>();
-    auth.put("bcryptLogRounds", env.BCRYPT_LOG_ROUNDS());
-    auth.put("cookieSecure", env.AUTH_COOKIE_SECURE());
-    auth.put("cookieDomain", env.AUTH_COOKIE_DOMAIN());
-    auth.put("cookieSameSite", env.AUTH_COOKIE_SAMESITE());
-    auth.put("cookiePath", env.AUTH_COOKIE_PATH());
-    configSummary.put("auth", auth);
-
-    log.info("Configuration loaded", v("config", configSummary));
+    log.info("Configuration loaded", v("config", result.toMap()));
     return result;
   }
 

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
@@ -11,7 +11,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import static net.logstash.logback.argument.StructuredArguments.v;
+
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
@@ -205,11 +209,37 @@ public class ConfigurationFactory {
     ApplicationConfiguration result =
         new ApplicationConfiguration(
             env, DatabaseVariables.generate(dbHost, dbPort, dbName, dbUser, dbPassword));
-    if (appEnv != AppEnv.PROD) { // is PROD check needed | useful?
-      // TODO: implement a mapper
-      // Some values will not be correctly shown. e.g. CORS_ALLOWED_ORIGINS
-      log.debug("Loaded Configuration: {}", result);
-    }
+
+    Map<String, Object> configSummary = new LinkedHashMap<>();
+    configSummary.put("environment", env.APP_ENV());
+
+    Map<String, Object> api = new LinkedHashMap<>();
+    api.put("url", env.API_URL());
+    api.put("port", env.API_PORT());
+    api.put("prefix", env.API_PREFIX());
+    api.put("corsOriginsCount", env.CORS_ALLOWED_ORIGINS().length);
+    configSummary.put("api", api);
+
+    Map<String, Object> database = new LinkedHashMap<>();
+    database.put("url", result.database().url());
+    database.put("user", result.database().user());
+    configSummary.put("database", database);
+
+    Map<String, Object> jwt = new LinkedHashMap<>();
+    jwt.put("issuer", env.JWT_ISSUER());
+    jwt.put("accessTokenExpirationMinutes", env.JWT_ACCESS_EXPIRATION_TIME_MINUTES());
+    jwt.put("refreshTokenExpirationDays", env.JWT_REFRESH_EXPIRATION_TIME_DAYS().toDays());
+    configSummary.put("jwt", jwt);
+
+    Map<String, Object> auth = new LinkedHashMap<>();
+    auth.put("bcryptLogRounds", env.BCRYPT_LOG_ROUNDS());
+    auth.put("cookieSecure", env.AUTH_COOKIE_SECURE());
+    auth.put("cookieDomain", env.AUTH_COOKIE_DOMAIN());
+    auth.put("cookieSameSite", env.AUTH_COOKIE_SAMESITE());
+    auth.put("cookiePath", env.AUTH_COOKIE_PATH());
+    configSummary.put("auth", auth);
+
+    log.info("Configuration loaded", v("config", configSummary));
     return result;
   }
 

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/AccessLogConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/AccessLogConfig.java
@@ -1,0 +1,39 @@
+package com.anibalxyz.server.config.modules.runtime;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import io.javalin.Javalin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class AccessLogConfig extends RuntimeConfig {
+
+  public static final String REQUEST_START_TIME_ATTR = "requestStartTime";
+  private static final Logger log = LoggerFactory.getLogger("reconciler.access");
+
+  public AccessLogConfig(Javalin server) {
+    super(server);
+  }
+
+  @Override
+  public void apply() {
+    server.before(ctx -> ctx.attribute(REQUEST_START_TIME_ATTR, System.currentTimeMillis()));
+
+    server.after(
+        ctx -> {
+          MDC.put("status", String.valueOf(ctx.statusCode()));
+          Long startTime = ctx.attribute(REQUEST_START_TIME_ATTR);
+          if (startTime == null) return;
+
+          long duration = System.currentTimeMillis() - startTime;
+          log.info(
+              "{} {} -> {} [{}ms]",
+              ctx.method(),
+              ctx.path(),
+              ctx.statusCode(),
+              duration,
+              kv("duration", duration));
+        });
+  }
+}

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
@@ -6,7 +6,6 @@ import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.InfrastructureErrorMapper;
 import com.anibalxyz.server.api.LogEntry;
 import com.anibalxyz.server.context.RequestContext;
-import org.slf4j.event.Level;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.http.HandlerType;
@@ -14,6 +13,9 @@ import io.javalin.http.HttpResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.slf4j.event.Level;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
 
 // TODO: use a more semantic name for this class
 public class ExceptionsConfig extends RuntimeConfig {
@@ -33,7 +35,7 @@ public class ExceptionsConfig extends RuntimeConfig {
           ErrorResult result = ErrorMapper.map(e.getError());
           String requestId = ctx.attribute(RequestContext.REQUEST_ID_KEY);
           MDC.put("status", String.valueOf(result.status()));
-          emitLogEntry(result.logEntry());
+          emitLogEntry(result);
 
           ctx.status(result.status()).json(result.response().instance(requestId));
         });
@@ -58,25 +60,36 @@ public class ExceptionsConfig extends RuntimeConfig {
     ErrorResult result = InfrastructureErrorMapper.map(e);
     String requestId = ctx.attribute(RequestContext.REQUEST_ID_KEY);
     MDC.put("status", String.valueOf(result.status()));
-    emitLogEntry(result.logEntry());
+    emitLogEntry(result);
 
     if (result.status() >= 500) {
-      log.error("{}: {}", e.getClass().getSimpleName(), e.getMessage());
+      log.error("{}: {}", e.getClass().getSimpleName(), e.getMessage(), kv("error_code", result.response().code()));
     } else {
-      log.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage());
+      log.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage(), kv("error_code", result.response().code()));
     }
 
     ctx.status(result.status()).json(result.response().instance(requestId));
   }
 
-  private void emitLogEntry(LogEntry entry) {
+  private void emitLogEntry(ErrorResult result) {
+    LogEntry entry = result.logEntry();
     if (entry == null) return;
-    switch (entry.level()) {
-      case WARN -> log.warn(entry.message(), entry.args());
-      case DEBUG -> log.debug(entry.message(), entry.args());
-      case INFO -> log.info(entry.message(), entry.args());
-      case ERROR -> log.error(entry.message(), entry.args());
-      case TRACE -> log.trace(entry.message(), entry.args());
+    String errorCode = result.response().code();
+    Level level = entry.level();
+    String message = entry.message();
+    Object[] args = entry.args();
+
+    if (errorCode != null && !errorCode.isEmpty()) {
+      args = java.util.Arrays.copyOf(args, args.length + 1);
+      args[args.length - 1] = kv("error_code", errorCode);
+    }
+
+    switch (level) {
+      case WARN -> log.warn(message, args);
+      case DEBUG -> log.debug(message, args);
+      case INFO -> log.info(message, args);
+      case ERROR -> log.error(message, args);
+      case TRACE -> log.trace(message, args);
     }
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
@@ -4,7 +4,9 @@ import com.anibalxyz.features.common.application.exception.FailureSignal;
 import com.anibalxyz.server.api.ErrorMapper;
 import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.InfrastructureErrorMapper;
+import com.anibalxyz.server.api.LogEntry;
 import com.anibalxyz.server.context.RequestContext;
+import org.slf4j.event.Level;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.http.HandlerType;
@@ -31,6 +33,7 @@ public class ExceptionsConfig extends RuntimeConfig {
           ErrorResult result = ErrorMapper.map(e.getError());
           String requestId = ctx.attribute(RequestContext.REQUEST_ID_KEY);
           MDC.put("status", String.valueOf(result.status()));
+          emitLogEntry(result.logEntry());
 
           ctx.status(result.status()).json(result.response().instance(requestId));
         });
@@ -55,6 +58,7 @@ public class ExceptionsConfig extends RuntimeConfig {
     ErrorResult result = InfrastructureErrorMapper.map(e);
     String requestId = ctx.attribute(RequestContext.REQUEST_ID_KEY);
     MDC.put("status", String.valueOf(result.status()));
+    emitLogEntry(result.logEntry());
 
     if (result.status() >= 500) {
       log.error("{}: {}", e.getClass().getSimpleName(), e.getMessage());
@@ -63,5 +67,16 @@ public class ExceptionsConfig extends RuntimeConfig {
     }
 
     ctx.status(result.status()).json(result.response().instance(requestId));
+  }
+
+  private void emitLogEntry(LogEntry entry) {
+    if (entry == null) return;
+    switch (entry.level()) {
+      case WARN -> log.warn(entry.message(), entry.args());
+      case DEBUG -> log.debug(entry.message(), entry.args());
+      case INFO -> log.info(entry.message(), entry.args());
+      case ERROR -> log.error(entry.message(), entry.args());
+      case TRACE -> log.trace(entry.message(), entry.args());
+    }
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/MetricsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/MetricsConfig.java
@@ -1,0 +1,68 @@
+package com.anibalxyz.server.config.modules.runtime;
+
+import io.javalin.Javalin;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetricsConfig extends RuntimeConfig {
+
+  public static final String METRICS_PATH = "/internal/metrics";
+  public static final String METRICS_TIMER_ATTR = "metrics_timer";
+  private static final Logger log = LoggerFactory.getLogger(MetricsConfig.class);
+  private final PrometheusMeterRegistry registry;
+
+  public MetricsConfig(Javalin server) {
+    super(server);
+    registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+  }
+
+  @Override
+  @SuppressWarnings("resource") // JvmGcMetrics already closed
+  public void apply() {
+    new ClassLoaderMetrics().bindTo(registry);
+    new JvmMemoryMetrics().bindTo(registry);
+    new JvmGcMetrics().bindTo(registry);
+    new JvmThreadMetrics().bindTo(registry);
+    new ProcessorMetrics().bindTo(registry);
+    new UptimeMetrics().bindTo(registry);
+
+    server.before(ctx -> ctx.attribute(METRICS_TIMER_ATTR, Timer.start(registry)));
+
+    server.after(
+        ctx -> {
+          Timer.Sample sample = ctx.attribute(METRICS_TIMER_ATTR);
+          if (sample == null) return;
+
+          sample.stop(
+              Timer.builder("http_server_requests")
+                  .description("HTTP request duration")
+                  .tag("method", ctx.method().name())
+                  .tag("path", ctx.matchedPath())
+                  .tag("status", String.valueOf(ctx.statusCode()))
+                  .register(registry));
+        });
+
+    server.get(
+        METRICS_PATH,
+        ctx -> {
+          ctx.contentType("text/plain; version=0.0.4; charset=utf-8");
+          ctx.result(registry.scrape());
+        });
+
+    log.info("Metrics endpoint registered at {}", METRICS_PATH);
+  }
+
+  // TODO: pending to be used
+  public void close() {
+    registry.close();
+  }
+}

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/SchedulerConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/SchedulerConfig.java
@@ -1,5 +1,7 @@
 package com.anibalxyz.server.config.modules.runtime;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.anibalxyz.features.auth.application.RefreshTokenService;
 import io.javalin.Javalin;
 import java.util.concurrent.Executors;
@@ -34,7 +36,7 @@ public class SchedulerConfig extends RuntimeConfig {
     scheduler.scheduleAtFixedRate(
         () -> {
           int deletedCount = refreshTokenService.cleanupExpiredTokens();
-          log.info("Finished scheduled refresh token cleanup. Deleted {} tokens.", deletedCount);
+          log.info("Finished scheduled refresh token cleanup", kv("deleted_count", deletedCount));
         },
         0,
         24,

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/ServerConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/ServerConfig.java
@@ -21,15 +21,24 @@ public class ServerConfig extends StartupConfig {
     this.env = env;
   }
 
-  @Override
-  public void apply() {
-    javalinConfig.useVirtualThreads = true;
-    javalinConfig.router.ignoreTrailingSlashes = true;
-    javalinConfig.jetty.modifyServer(server -> server.setStopTimeout(5_000)); // graceful shutdown
-    javalinConfig.http.defaultContentType = "application/json; charset=utf-8";
-    String[] hosts = env.CORS_ALLOWED_ORIGINS();
+  private static void overrideIpGetter(JavalinConfig config) {
+    config.contextResolver.ip =
+        ctx -> {
+          String ip = ctx.header("X-Real-IP");
+          return (ip != null && !ip.isBlank()) ? ip : ctx.req().getRemoteAddr();
+        };
+  }
+
+  private static void configureJsonMapper(JavalinConfig config) {
+    config.jsonMapper(
+        new JavalinJackson()
+            .updateMapper(
+                mapper -> mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)));
+  }
+
+  private static void configureCors(JavalinConfig config, String[] hosts) {
     if (hosts != null && hosts.length > 0) {
-      javalinConfig.bundledPlugins.enableCors(
+      config.bundledPlugins.enableCors(
           cors ->
               cors.addRule(
                   rule -> {
@@ -41,9 +50,17 @@ public class ServerConfig extends StartupConfig {
     } else {
       log.warn("CORS_ALLOWED_ORIGINS not set. CORS will reject all origins");
     }
-    javalinConfig.jsonMapper(
-        new JavalinJackson()
-            .updateMapper(
-                mapper -> mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)));
+  }
+
+  @Override
+  public void apply() {
+    javalinConfig.useVirtualThreads = true;
+    javalinConfig.router.ignoreTrailingSlashes = true;
+    javalinConfig.jetty.modifyServer(server -> server.setStopTimeout(5_000)); // graceful shutdown
+    javalinConfig.http.defaultContentType = "application/json; charset=utf-8";
+
+    configureCors(javalinConfig, env.CORS_ALLOWED_ORIGINS());
+    configureJsonMapper(javalinConfig);
+    overrideIpGetter(javalinConfig);
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
@@ -17,6 +17,7 @@ import org.slf4j.MDC;
 public class RequestContext {
 
   public static final String REQUEST_ID_KEY = "request_id";
+  public static final String USER_ID_KEY = "user_id";
 
   private RequestContext() {}
 
@@ -34,6 +35,7 @@ public class RequestContext {
     MDC.put(REQUEST_ID_KEY, requestId);
     MDC.put("method", ctx.method().name());
     MDC.put("path", ctx.path());
+    setUserId("anonymous");
 
     return requestId;
   }
@@ -55,5 +57,13 @@ public class RequestContext {
    */
   public static void clear() {
     MDC.clear();
+  }
+
+  private static void setUserId(String userId) {
+    MDC.put(USER_ID_KEY, userId);
+  }
+
+  public static void setUserId(int userId) {
+    setUserId(String.valueOf(userId));
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/context/RequestContext.java
@@ -33,20 +33,12 @@ public class RequestContext {
     String requestId = "req-" + UUID.randomUUID();
 
     MDC.put(REQUEST_ID_KEY, requestId);
+    MDC.put("client_ip", ctx.ip());
     MDC.put("method", ctx.method().name());
     MDC.put("path", ctx.path());
     setUserId("anonymous");
 
     return requestId;
-  }
-
-  /**
-   * Retrieves the current request ID from the MDC.
-   *
-   * @return the request ID, or null if called outside a request context
-   */
-  public static String getCurrentRequestId() {
-    return MDC.get(REQUEST_ID_KEY);
   }
 
   /**

--- a/backend/api/src/main/resources/logback.xml
+++ b/backend/api/src/main/resources/logback.xml
@@ -3,6 +3,7 @@
 
     <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>client_ip</includeMdcKeyName>
             <includeMdcKeyName>request_id</includeMdcKeyName>
             <includeMdcKeyName>user_id</includeMdcKeyName>
             <includeMdcKeyName>path</includeMdcKeyName>


### PR DESCRIPTION
## What

Adds the observability instrumentation layer: Prometheus metrics endpoint, HTTP access logging, client IP tracking, user context in logs, business event logging across the  service layer, structured startup diagnostics, and centralized error log emission.

PR #24 established structured JSON logging and per-request correlation IDs. This PR makes the system observable end-to-end.

## Why

Without this instrumentation, the API is a black box. There is no way to:

- **Measure**: Whether the system is healthy, how many requests it's serving, how long they take, or whether errors are spiking (metrics)
- **Audit**: Who accessed what, when, and what happened (access log with `user_id`, `method`, `path`, `status`, `duration`)
- **Correlate**: Which log entries belong to a single request across service boundaries (MDC with `request_id`, `user_id`, `client_ip`)
- **Diagnose startup**: Whether the configuration loaded correctly, the database connected, or the server bound to the expected port (startup logs)
- **Track business events**: Key domain events (user created, authenticated, token refreshed) are invisible in the current log stream
- **Centralize error logging**: Error mappers log directly via SLF4J, missing `status` in the MDC context, and scattered log statements throughout feature code

Each of these gaps makes production incidents harder to debug and reduces confidence in deployments. This PR closes all of them.

## How

### 1. Prometheus Metrics (`MetricsConfig`)

`micrometer-registry-prometheus` (1.16.5) added. `MetricsConfig` registers:

- JVM metrics: memory, GC, threads, class loader
- System metrics: CPU, uptime
- HTTP RED metrics per `(method, path, status)` via `Timer.builder("http_server_requests")`

Exposes `/internal/metrics` in Prometheus text format. Path intentionally outside `/api` prefix; internal endpoint not meant for public access.

### 2. HTTP Access Logging (`AccessLogConfig`)

One `INFO` line per completed request via `reconciler.access` logger.
Duration tracked via `requestStartTime` context attribute. `status` added to MDC in the `after()` hook so it's present in all log entries for that request, including 2xx responses (which never pass through `ExceptionsConfig`).

```json
{
  "@timestamp": "2026-05-12T18:42:57.445812172Z",
  "@version": "1",
  "message": "POST /api/auth/logout -> 204 [10ms]",
  "logger_name": "reconciler.access",
  "thread_name": "JettyServerThreadPool-Virtual-14",
  "level": "INFO",
  "level_value": 20000,
  "path": "/api/auth/logout",
  "client_ip": "172.20.0.1",
  "method": "POST",
  "user_id": "anonymous",
  "request_id": "req-9dca888b-fec4-4f86-9862-ed909c1d8919",
  "status": "204",
  "duration": 10,
  "service": "reconciler-api"
}
```

### 3. Client IP in MDC

`contextResolver.ip` overridden in `ServerConfig` to read `X-Real-IP` header (set by nginx to `$remote_addr`, not spoofable). Falls back to `ctx.req().getRemoteAddr()` for direct connections in dev. `client_ip` populated in MDC by `RequestContext.initialize()`.

### 4. User Context in MDC

`user_id` defaulted to `"anonymous"` on every request. Overwritten with the actual integer user ID in two places:

- `JwtMiddleware`: on every authenticated request (JWT validated)
- `AuthService.authenticate()`: on successful login (before JWT exists)

### 5. Business Event Logging

| Class                 | Event                        | Level                        |
| --------------------- | ---------------------------- | ---------------------------- |
| `AuthService`         | User authenticated           | INFO                         |
| `AuthService`         | Tokens refreshed             | INFO                         |
| `AuthController`      | User logged out              | INFO                         |
| `UserService`         | User created/updated/deleted | INFO                         |
| `SchedulerConfig`     | Cleanup completed            | INFO + `kv("deleted_count")` |

All messages are clean strings. `user_id`, `request_id`, and `client_ip` flow through MDC automatically. No data duplicated in message text.

### 6. Centralized Error Log Emission (`LogEntry` + `ExceptionsConfig`)

Previously, error mappers logged directly via SLF4J, scattering log calls throughout feature code. Now:

```txt
ErrorMapper.map(error)
  └──> ErrorResult(status, response, LogEntry?)    <- typed, no side effects
        └──> ExceptionsConfig.emitLogEntry()       <- logs after MDC.put("status")
              └──> switch(entry.level())           <- org.slf4j.event.Level enum
```

- `LogEntry` (new): carries a `(Level, message, args...)` triplet. Factory methods `LogEntry.warn()` and `LogEntry.debug()` for ergonomic creation.
- `ErrorResult` record: added optional `LogEntry` as a third component. Original two-arg constructor defaults it to `null` for error responses that don't need logging.
- `ExceptionsConfig.emitLogEntry()`: consumes the `LogEntry` via a switch on `org.slf4j.event.Level`.
- `status` is set in MDC **before** `emitLogEntry()`, so every error log carries the HTTP status code.
- `error_code` is appended as a structured argument (`kv("error_code", ...)`) from `ErrorResponse.code()`, so every error log includes the machine-readable error code.

Example output for a 401:

```json
{
  "@timestamp": "2026-05-12T18:57:37.286415743Z",
  "@version": "1",
  "message": "Invalid credentials attempt",
  "logger_name": "com.anibalxyz.server.config.modules.runtime.ExceptionsConfig",
  "thread_name": "JettyServerThreadPool-Virtual-20",
  "level": "WARN",
  "level_value": 30000,
  "path": "/api/auth/login",
  "client_ip": "172.20.0.1",
  "method": "POST",
  "user_id": "anonymous",
  "request_id": "req-e35f0d5b-fdc9-4742-84c7-222ec19ee424",
  "status": "401",
  "error_code": "UNAUTHORIZED",
  "service": "reconciler-api"
}
```

### 7. Startup Diagnostics

- `ConfigurationFactory`: structured startup log using `v("config", config.toMap())` with nested JSON (api, database, jwt, auth sections). `JWT_KEY` masked.
- `PersistenceManager`: logs DB pool init and successful EMF creation.
- `Application.start()`: logs port + env before bind, API URL after ready.
- `AppEnvironmentSource.toString()`: sanitized implementation masking `JWT_KEY`.
- `ApplicationConfiguration.toMap()`: extracts config summary for structured logging.

### 8. ServerConfig Refactor

`apply()` extracted into `configureCors()`, `configureJsonMapper()`, and `overrideIpGetter()` for readability.

### Architecture decisions

**Error logs are centralized in the web adapter**, not in the core. Centralized error handling belongs to the adapter layer because HTTP-specific context (status code, error code) is involved. A future CLI adapter would need its own error handling; the service layer emits `Result.failure(error)` which any adapter can interpret.

**Business event logs (INFO) live in the service layer via SLF4J**, which is a pragmatic decision. Strictly speaking this leaks infrastructure to the core, but in practice SLF4J is a stable standard with zero runtime overhead and no exotic dependencies. These will migrate to domain events when the project introduces an event bus; at that point the service will emit `UserAuthenticated(userId)` and the adapter will subscribe and log.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass
- [x] Manual testing completed
  - `/internal/metrics` returns valid Prometheus text format
  - Access logs appear with correct duration and status on every request
  - `user_id` transitions from `"anonymous"` to actual user ID on login
  - Startup logs show full configuration summary with masked secrets
  - Error logs carry `status` via centralized emission

## Other information

**Security considerations:**

- `/internal/metrics` should be firewalled in production, not proxied through nginx to public clients. The `/internal/` prefix signals this intent.
- `JWT_KEY` is masked in all startup logs.
- Error log messages contain the failure reason, never the submitted password.
- No PII (email, username) in any log message; correlation via `user_id` only.