### PR TITLE
fix: public site error handling and ci typescript type checking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,10 @@ jobs:
         working-directory: frontend
         run: npm run format:check
 
+      - name: Run TypeScript type check
+        working-directory: frontend
+        run: npm run typecheck
+
   test:
     name: Tests
     needs: lint

--- a/compose.monitoring.yaml
+++ b/compose.monitoring.yaml
@@ -48,6 +48,7 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      # TODO: solve alert when running in dev: DOMAIN not set
       - GF_SERVER_ROOT_URL=https://${DOMAIN}/grafana/
       - GF_INSTALL_PLUGINS=
     volumes:

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd frontend && npx lint-staged

--- a/frontend/.lintstagedrc.js
+++ b/frontend/.lintstagedrc.js
@@ -1,0 +1,3 @@
+export default {
+  '**/*.{js,ts,css,json,md,yaml,yml}': ['prettier --write'],
+};

--- a/frontend/common/services/AuthService.ts
+++ b/frontend/common/services/AuthService.ts
@@ -2,9 +2,13 @@ export interface AuthResponse {
   accessToken: string;
 }
 
+// TODO: this is NOT the real backend ErrorDetail structure.
+//       The real record only guarantees `code` (String).
+//       `title` and `field` are assumptions based on current validation errors
 export interface ErrorDetail {
-  field: string;
-  message: string;
+  code: string;
+  title: string;
+  field?: string;
 }
 
 export interface ErrorResponse {

--- a/frontend/dashboard/.lintstagedrc.js
+++ b/frontend/dashboard/.lintstagedrc.js
@@ -1,0 +1,6 @@
+import baseConfig from '../.lintstagedrc.js';
+
+export default {
+  ...baseConfig,
+  '**/*.{jsx,tsx}': ['prettier --write'],
+};

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@anibalxyz/reconciler-dashboard",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "vite build",
     "dev": "vite",

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -7,7 +7,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "19.2.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,8 @@
         "@types/node": "24.0.0",
         "eslint": "9.39.1",
         "eslint-config-prettier": "10.1.8",
+        "husky": "^9.1.7",
+        "lint-staged": "^17.0.5",
         "prettier": "3.6.2",
         "prettier-plugin-astro": "0.14.1",
         "prettier-plugin-tailwindcss": "0.7.1",
@@ -2769,6 +2771,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -3420,6 +3438,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -3869,6 +3937,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -4255,9 +4336,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -4468,9 +4549,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4773,6 +4854,22 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5314,6 +5411,96 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
+      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.1.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.8.4"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5336,6 +5523,72 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -6230,6 +6483,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -6364,6 +6630,22 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
@@ -6548,9 +6830,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7003,6 +7285,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/restructure": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
@@ -7080,6 +7379,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.52.5",
@@ -7272,11 +7578,70 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/smol-toml": {
       "version": "1.5.2",
@@ -7307,6 +7672,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-ts": {
@@ -7465,9 +7840,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,8 @@
     "dev:public": "npm run dev --workspace=@anibalxyz/reconciler-public-site",
     "format": "npm run format --workspaces",
     "format:check": "npm run format:check --workspaces",
-    "lint": "npm run lint --workspaces"
+    "lint": "npm run lint --workspaces",
+    "typecheck": "npm run typecheck --workspaces"
   },
   "dependencies": {
     "@tailwindcss/vite": "4.1.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "email": "anibalboggioict@gmail.com",
     "url": "https://github.com/anibalxyz"
   },
+  "type": "module",
   "workspaces": [
     "dashboard",
     "public-site"
@@ -42,6 +43,7 @@
     "format": "npm run format --workspaces",
     "format:check": "npm run format:check --workspaces",
     "lint": "npm run lint --workspaces",
+    "prepare": "cd .. && husky ./frontend/.husky",
     "typecheck": "npm run typecheck --workspaces"
   },
   "dependencies": {
@@ -53,6 +55,8 @@
     "@types/node": "24.0.0",
     "eslint": "9.39.1",
     "eslint-config-prettier": "10.1.8",
+    "husky": "9.1.7",
+    "lint-staged": "17.0.5",
     "prettier": "3.6.2",
     "prettier-plugin-astro": "0.14.1",
     "prettier-plugin-tailwindcss": "0.7.1",

--- a/frontend/public-site/.lintstagedrc.js
+++ b/frontend/public-site/.lintstagedrc.js
@@ -1,0 +1,6 @@
+import baseConfig from '../.lintstagedrc.js';
+
+export default {
+  ...baseConfig,
+  '**/*.astro': ['prettier --write'],
+};

--- a/frontend/public-site/package.json
+++ b/frontend/public-site/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@anibalxyz/reconciler-public-site",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "astro build",
     "dev": "astro dev",

--- a/frontend/public-site/package.json
+++ b/frontend/public-site/package.json
@@ -7,7 +7,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "astro": "5.16.5"

--- a/frontend/public-site/src/scripts/login.ts
+++ b/frontend/public-site/src/scripts/login.ts
@@ -1,6 +1,6 @@
 // NOTE: could refactor with `register.ts` but isnt a priority,
 // it will not visibly improve the performance
-import AuthService from '@common/services/AuthService';
+import AuthService, { type ErrorResponse } from '@common/services/AuthService';
 import { loginSchema } from '@validation/authSchemas';
 import { updateValidationErrors } from './ui';
 
@@ -16,22 +16,27 @@ loginForm.addEventListener('submit', async (event) => {
   const formData = loginSchema.safeParse(Object.fromEntries(new FormData(loginForm)));
   if (!formData.success) {
     const errors = Object.values(formData.error.flatten().fieldErrors).flatMap((msgs) => msgs ?? []);
-    updateValidationErrors(validationErrorDiv, validationErrorList, errors);
+    updateValidationErrors(
+      validationErrorDiv,
+      validationErrorList,
+      errors.map((msg) => ({ code: 'VALIDATION_ERROR', title: msg })),
+    );
     return;
   }
 
   const { email, password } = formData.data;
 
   const response = await authService.loginUser(email, password);
-  if ('error' in response.data) {
-    updateValidationErrors(validationErrorDiv, validationErrorList, response.data.details);
+  if ('accessToken' in response.data) {
+    validationErrorDiv.classList.add('invisible');
+    successModal.showModal();
+    successModal.addEventListener('close', () => {
+      window.location.href = '/dashboard';
+    });
     return;
   }
 
-  validationErrorDiv.classList.add('invisible'); // after login -> smoother transition
-
-  successModal.showModal();
-  successModal.addEventListener('close', () => {
-    window.location.href = '/dashboard';
-  });
+  const errorData = response.data as ErrorResponse;
+  const errorDetails = errorData.errors?.length ? errorData.errors : [{ code: errorData.code, title: errorData.title }];
+  updateValidationErrors(validationErrorDiv, validationErrorList, errorDetails);
 });

--- a/frontend/public-site/src/scripts/register.ts
+++ b/frontend/public-site/src/scripts/register.ts
@@ -1,4 +1,4 @@
-import AuthService from '@common/services/AuthService';
+import AuthService, { type ErrorResponse } from '@common/services/AuthService';
 import { registerSchema } from '@validation/authSchemas';
 import { updateValidationErrors } from './ui';
 
@@ -14,26 +14,34 @@ registerForm.addEventListener('submit', async (event) => {
   const formData = registerSchema.safeParse(Object.fromEntries(new FormData(registerForm)));
   if (!formData.success) {
     const errors = Object.values(formData.error.flatten().fieldErrors).flatMap((msgs) => msgs ?? []);
-    updateValidationErrors(validationErrorDiv, validationErrorList, errors);
+    updateValidationErrors(
+      validationErrorDiv,
+      validationErrorList,
+      errors.map((msg) => ({ code: 'VALIDATION_ERROR', title: msg })),
+    );
     return;
   }
 
   const { name, email, password } = formData.data;
 
   const responseRegister = await authService.registerUser(name, email, password);
-  if ('error' in responseRegister.data) {
-    updateValidationErrors(validationErrorDiv, validationErrorList, responseRegister.data.details);
+  if ('id' in responseRegister.data) {
+    // registration succeeded, now login
+    const responseLogin = await authService.loginUser(email, password);
+    if ('accessToken' in responseLogin.data) {
+      validationErrorDiv.classList.add('invisible');
+      successModal.showModal();
+      successModal.addEventListener('close', () => (window.location.href = '/dashboard'), { once: true });
+      return;
+    }
+
+    const loginError = responseLogin.data as ErrorResponse;
+    const loginDetails = loginError.errors?.length ? loginError.errors : [{ code: loginError.code, title: loginError.title }];
+    updateValidationErrors(validationErrorDiv, validationErrorList, loginDetails);
     return;
   }
 
-  const responseLogin = await authService.loginUser(email, password);
-  if ('error' in responseLogin.data) {
-    updateValidationErrors(validationErrorDiv, validationErrorList, responseLogin.data.details);
-    return;
-  }
-
-  validationErrorDiv.classList.add('invisible'); // after login -> smoother transition
-
-  successModal.showModal();
-  successModal.addEventListener('close', () => (window.location.href = '/dashboard'), { once: true });
+  const registerError = responseRegister.data as ErrorResponse;
+  const registerDetails = registerError.errors?.length ? registerError.errors : [{ code: registerError.code, title: registerError.title }];
+  updateValidationErrors(validationErrorDiv, validationErrorList, registerDetails);
 });

--- a/frontend/public-site/src/scripts/register.ts
+++ b/frontend/public-site/src/scripts/register.ts
@@ -36,12 +36,16 @@ registerForm.addEventListener('submit', async (event) => {
     }
 
     const loginError = responseLogin.data as ErrorResponse;
-    const loginDetails = loginError.errors?.length ? loginError.errors : [{ code: loginError.code, title: loginError.title }];
+    const loginDetails = loginError.errors?.length
+      ? loginError.errors
+      : [{ code: loginError.code, title: loginError.title }];
     updateValidationErrors(validationErrorDiv, validationErrorList, loginDetails);
     return;
   }
 
   const registerError = responseRegister.data as ErrorResponse;
-  const registerDetails = registerError.errors?.length ? registerError.errors : [{ code: registerError.code, title: registerError.title }];
+  const registerDetails = registerError.errors?.length
+    ? registerError.errors
+    : [{ code: registerError.code, title: registerError.title }];
   updateValidationErrors(validationErrorDiv, validationErrorList, registerDetails);
 });

--- a/frontend/public-site/src/scripts/ui.ts
+++ b/frontend/public-site/src/scripts/ui.ts
@@ -4,11 +4,7 @@ function errorDetailToString(e: ErrorDetail): string {
   return e.field ? `${e.field}: ${e.title}` : e.title;
 }
 
-export function updateValidationErrors(
-  errDiv: HTMLDivElement,
-  errList: HTMLUListElement,
-  errors: ErrorDetail[],
-) {
+export function updateValidationErrors(errDiv: HTMLDivElement, errList: HTMLUListElement, errors: ErrorDetail[]) {
   errList.innerHTML = '';
   errors.forEach((e) => {
     const li = document.createElement('li');

--- a/frontend/public-site/src/scripts/ui.ts
+++ b/frontend/public-site/src/scripts/ui.ts
@@ -1,8 +1,18 @@
-export function updateValidationErrors(errDiv: HTMLDivElement, errList: HTMLUListElement, errors: string[]) {
+import type { ErrorDetail } from '@common/services/AuthService';
+
+function errorDetailToString(e: ErrorDetail): string {
+  return e.field ? `${e.field}: ${e.title}` : e.title;
+}
+
+export function updateValidationErrors(
+  errDiv: HTMLDivElement,
+  errList: HTMLUListElement,
+  errors: ErrorDetail[],
+) {
   errList.innerHTML = '';
-  errors.forEach((error) => {
+  errors.forEach((e) => {
     const li = document.createElement('li');
-    li.textContent = error;
+    li.textContent = errorDetailToString(e);
     errList.appendChild(li);
   });
   errDiv.classList.remove('invisible');


### PR DESCRIPTION
## What

Three changes bundled for delivery efficiency:

1. **Frontend error response handling fix**: login and register forms now correctly detect and display RFC 9457 error responses from the backend. The previous `'error' in response.data` check always evaluated to `false` because RFC 9457 has no `error` field — all error paths silently fell through to the success branch.
2. **TypeScript type checking in CI**: adds `typecheck` scripts to dashboard, public-site, and root, plus a CI step that catches type errors before merge.
3. **Pre-commit hook with lint-staged**: Husky pre-commit hook that auto-formats staged files via lint-staged with per-workspace configuration, inheriting from a shared base config.

## Why

**Error handling fix**: The login and register forms were broken since PR #20 introduced the RFC 9457 error format. Both `login.ts:33` and `register.ts:32` checked `'error' in response.data`, which is always `false` for RFC 9457 responses (the field is `code`, `title`, `errors`, etc.). The fix uses `'accessToken'` in login and `'id'` in register as the success discriminator instead.
**TypeScript typecheck in CI**: Type errors silently slip through build-only verification. A dedicated `tsc --noEmit` step catches structural type issues independently of the bundler, catching errors the build pipeline would miss.
**Pre-commit formatting**: No consistent formatting enforcement across the frontend workspace. Developers must remember to run formatters manually. Husky + lint-staged formats only staged files on commit, keeping the codebase consistently formatted with zero overhead.

## How

### Error handling fix

- **`login.ts`**: Changed discriminator from `'error' in response.data` (always false) to `'accessToken' in response.data`. On failure, casts to `ErrorResponse` and extracts errors from `errors[]` array or falls back to a single-element array from the top-level `code`/`title`. Success path (`validationErrorDiv.classList.add('invisible')`) moved back inside the success branch after the discriminator was fixed.
- **`register.ts`**: Same fix — discriminator `'id' in responseRegister.data` for registration success. Also restructured to check registration success first, then attempt auto-login, correcting the inverted success/error flow.
- **`ui.ts`**: `updateValidationErrors` now accepts `ErrorDetail[]` instead of `string[]`. New `errorDetailToString()` helper renders `"field: title"` or just `"title"` depending on whether the field is present.
- **`AuthService.ts`**: `ErrorDetail` interface corrected to match the backend record: `code` (required, the only guaranteed field), `title`, and optional `field`. Added TODO acknowledging this is not yet the full backend structure.

### TypeScript type check

- **`package.json`** (root, dashboard, public-site): added `"typecheck": "tsc --noEmit"` script.
- **Root `package.json`**: added `"typecheck": "npm run typecheck --workspaces"`.
- **`.github/workflows/ci.yaml`**: added `Run TypeScript type check` step in the `lint` job.

### Pre-commit formatting

- **`.husky/pre-commit`**: `cd frontend && npx lint-staged`. Husky 9 executes hooks from the git root, so the `cd frontend` correctly resolves `node_modules/.bin/lint-staged`.
- **`.lintstagedrc.js`** (root in `frontend/`): base config formatting `*.{js,ts,css,json,md,yaml,yml}` with Prettier.
- **`dashboard/.lintstagedrc.js`** and **`public-site/.lintstagedrc.js`**: inherit base config via spread (`...baseConfig`) and add workspace-specific patterns (`*.{jsx,tsx}`, `*.astro`).
- **`package.json`** (root): added `"prepare": "cd .. && husky ./frontend/.husky"` script for automatic hook installation on `npm install`.
- `package.json` files in root, dashboard, and public-site all set `"type": "module"` (required by lint-staged v17 ESM configs).

> [!NOTE]
> The pre-commit hook currently only works for the frontend, ignoring other directories.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Edge cases considered

## Other information

**Workspace `"type": "module"`**: The `package.json` files in `frontend/`, `dashboard/`, and `public-site/` now have `"type": "module"`. This was required by lint-staged v17's ESM config resolution but also brings the frontend workspace in line with modern Node.js conventions. All existing tools (Vite, Astro, ESLint, Prettier) already support ESM.
