### PR TITLE
feat: enable swagger in production

### DIFF
--- a/backend/.env.dev.example
+++ b/backend/.env.dev.example
@@ -21,6 +21,8 @@ SYSTEM_TIMEZONE=America/Montevideo
 # Format: ISO 8601 date-time (e.g., 2026-05-12T00:00:00Z)
 SYSTEM_TIME_OVERRIDE=
 
+SWAGGER_ENABLED=true
+
 # ---------------------------------------------- #
 # ==> Database Configuration                     #
 # ---------------------------------------------- #

--- a/backend/.env.dev.example
+++ b/backend/.env.dev.example
@@ -2,11 +2,9 @@
 # ==> Application Configuration                  #
 # ---------------------------------------------- #
 
-# Optional, defaults to 'http' in dev/test and 'https' in prod.
 API_PROTOCOL=http
 API_HOST=localhost
 API_PORT=4001
-API_PREFIX=/api
 
 # Comma-separated list of allowed origins for CORS.
 # The protocol is added automatically based on FRONTEND_PROTOCOL.
@@ -50,5 +48,5 @@ BCRYPT_LOG_ROUNDS=12
 AUTH_COOKIE_DOMAIN=
 # SameSite policy for the refresh token cookie. Available: None, Lax, Strict.
 AUTH_COOKIE_SAMESITE=Strict
-# Path for the refresh token cookie. It is relative to the API_PREFIX.
+# Path for the refresh token cookie. It is relative to /api.
 AUTH_COOKIE_PATH=/auth

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -21,6 +21,8 @@ CONTACT_EMAIL=anibalboggioict@gmail.com
 # Format: IANA timezone ID (e.g., America/Montevideo, UTC, Europe/Madrid)
 SYSTEM_TIMEZONE=America/Montevideo
 
+SWAGGER_ENABLED=false
+
 # ---------------------------------------------- #
 # ==> Database Configuration                     #
 # ---------------------------------------------- #

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -2,11 +2,11 @@
 # ==> Application Configuration                  #
 # ---------------------------------------------- #
 
-# Optional, defaults to 'http' in dev/test and 'https' in prod.
 API_PROTOCOL=https
 API_HOST=localhost
 API_PORT=4002
-API_PREFIX=/api
+
+API_PUBLIC_URL=
 
 # Comma-separated list of allowed origins for CORS.
 # The protocol is added automatically based on FRONTEND_PROTOCOL.
@@ -49,7 +49,7 @@ BCRYPT_LOG_ROUNDS=12
 AUTH_COOKIE_DOMAIN=
 # SameSite policy for the refresh token cookie. Available: None, Lax, Strict.
 AUTH_COOKIE_SAMESITE=Strict
-# Path for the refresh token cookie. It is relative to the API_PREFIX.
+# Path for the refresh token cookie. It is relative to /api.
 AUTH_COOKIE_PATH=/auth
 
 

--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -21,6 +21,8 @@ SYSTEM_TIMEZONE=America/Montevideo
 # Format: ISO 8601 date-time (e.g., 2026-05-12T00:00:00Z)
 SYSTEM_TIME_OVERRIDE=
 
+SWAGGER_ENABLED=false
+
 # ---------------------------------------------- #
 # ==> Database Configuration                     #
 # ---------------------------------------------- #

--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -2,11 +2,9 @@
 # ==> Application Configuration                  #
 # ---------------------------------------------- #
 
-# Optional, defaults to 'http' in dev/test and 'https' in prod.
 API_PROTOCOL=http
 API_HOST=localhost
 API_PORT=1
-API_PREFIX=/api
 
 # Comma-separated list of allowed origins for CORS.
 # The protocol is added automatically based on FRONTEND_PROTOCOL.
@@ -50,5 +48,5 @@ BCRYPT_LOG_ROUNDS=4
 AUTH_COOKIE_DOMAIN=
 # SameSite policy for the refresh token cookie. Available: None, Lax, Strict.
 AUTH_COOKIE_SAMESITE=Strict
-# Path for the refresh token cookie. It is relative to the API_PREFIX.
+# Path for the refresh token cookie. It is relative to /api.
 AUTH_COOKIE_PATH=/auth

--- a/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/auth/api/AuthErrorMapper.java
@@ -21,14 +21,13 @@ import com.anibalxyz.server.api.LogEntry;
 import com.anibalxyz.server.exception.UnhandledErrorException;
 import com.anibalxyz.server.exception.UnreachableCodeException;
 
-
 public class AuthErrorMapper implements FeatureErrorMapper {
 
   public ErrorResult mapInvalidCredentialsError() {
     return new ErrorResult(
         401,
         new ErrorResponse(CommonErrorCode.UNAUTHORIZED).detail("Invalid credentials"),
-      LogEntry.warn("Invalid credentials attempt"));
+        LogEntry.warn("Invalid credentials attempt"));
   }
 
   public ErrorResult mapAuthenticateUserError(AuthService.AuthenticateUserError error) {
@@ -40,9 +39,9 @@ public class AuthErrorMapper implements FeatureErrorMapper {
               503,
               new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
                   .detail("Service unavailable until " + e.availableFrom()),
-            LogEntry.debug(
-                    "Authentication during maintenance window",
-                    kv("available_from", e.availableFrom())));
+              LogEntry.debug(
+                  "Authentication during maintenance window",
+                  kv("available_from", e.availableFrom())));
       case AuthService.AuthenticateUserError.ValidationFailed e ->
           ValidationErrorMapper.map(e.notification(), ErrorMapper::mapFieldError);
     };
@@ -55,9 +54,9 @@ public class AuthErrorMapper implements FeatureErrorMapper {
               503,
               new ErrorResponse(CommonErrorCode.UNAVAILABLE_SERVICE)
                   .detail("Service unavailable until " + e.availableFrom()),
-            LogEntry.debug(
-                    "Token refresh during maintenance window",
-                    kv("available_from", e.availableFrom())));
+              LogEntry.debug(
+                  "Token refresh during maintenance window",
+                  kv("available_from", e.availableFrom())));
       case AuthService.RefreshTokensError.InvalidToken e -> mapInvalidRefreshTokenError(e.error());
     };
   }
@@ -68,17 +67,17 @@ public class AuthErrorMapper implements FeatureErrorMapper {
           new ErrorResult(
               401,
               new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND),
-                LogEntry.debug("Refresh token not found"));
+              LogEntry.debug("Refresh token not found"));
       case InvalidRefreshTokenError.Reason.Expired ignored ->
           new ErrorResult(
               401,
               new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED),
-                LogEntry.debug("Refresh token expired"));
+              LogEntry.debug("Refresh token expired"));
       case InvalidRefreshTokenError.Reason.Revoked ignored ->
           new ErrorResult(
               401,
               new ErrorResponse(AuthErrorCode.REFRESH_TOKEN_EXPIRED),
-                LogEntry.warn("Revoked refresh token used"));
+              LogEntry.warn("Revoked refresh token used"));
     };
   }
 
@@ -130,8 +129,7 @@ public class AuthErrorMapper implements FeatureErrorMapper {
           new ErrorResult(
               401, base.detail("Missing JWT token"), LogEntry.warn("Missing JWT token"));
       case JwtService.JwtValidationError.Expired ignored ->
-          new ErrorResult(
-              401, base.detail("JWT has expired"), LogEntry.debug("JWT has expired"));
+          new ErrorResult(401, base.detail("JWT has expired"), LogEntry.debug("JWT has expired"));
     };
   }
 

--- a/backend/api/src/main/java/com/anibalxyz/features/users/api/UserErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/features/users/api/UserErrorMapper.java
@@ -17,7 +17,6 @@ import com.anibalxyz.server.api.LogEntry;
 import com.anibalxyz.server.exception.UnhandledErrorException;
 import com.anibalxyz.server.exception.UnreachableCodeException;
 
-
 public class UserErrorMapper implements FeatureErrorMapper {
 
   public ErrorResult mapUserNotFoundError(UserNotFoundError error) {

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -98,6 +98,8 @@ public class Application {
           if (config.env().SWAGGER_ENABLED()) {
             container.server().get("/", ctx -> ctx.redirect("/swagger"));
             container.server().get("/api", ctx -> ctx.redirect("/swagger"));
+
+            container.server().after("/swagger", SwaggerConfig::swaggerPatch);
           }
 
           new AccessLogConfig(container.server()).apply();

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -82,7 +82,9 @@ public class Application {
     // 1. Declare specific startup configurations for dev/prod
     Consumer<JavalinConfig> startupConfig =
         javalinConfig -> {
-          new SwaggerConfig(javalinConfig, config.env()).apply();
+          if (config.env().SWAGGER_ENABLED()) {
+            new SwaggerConfig(javalinConfig, config.env()).apply();
+          }
           javalinConfig.registerPlugin(
               new MicrometerPlugin(
                   micrometerPluginConfig ->
@@ -93,9 +95,10 @@ public class Application {
     // TODO: move to a separate file, e.g. RedirectRoutes within features.common
     Consumer<DependencyContainer> runtimeConfigs =
         container -> {
-          String openapiRedirect = appEnv == AppEnv.PROD ? "/openapi" : "/swagger";
-          container.server().get("/", ctx -> ctx.redirect(openapiRedirect));
-          container.server().get("/api", ctx -> ctx.redirect(openapiRedirect));
+          if (config.env().SWAGGER_ENABLED()) {
+            container.server().get("/", ctx -> ctx.redirect("/swagger"));
+            container.server().get("/api", ctx -> ctx.redirect("/swagger"));
+          }
 
           new AccessLogConfig(container.server()).apply();
           new MetricsConfig(container.server(), prometheusMeterRegistry).apply();

--- a/backend/api/src/main/java/com/anibalxyz/server/Application.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/Application.java
@@ -99,7 +99,9 @@ public class Application {
             container.server().get("/", ctx -> ctx.redirect("/swagger"));
             container.server().get("/api", ctx -> ctx.redirect("/swagger"));
 
-            container.server().after("/swagger", SwaggerConfig::swaggerPatch);
+            container
+                .server()
+                .after("/swagger", ctx -> SwaggerConfig.swaggerPatch(ctx, config.env().APP_ENV()));
           }
 
           new AccessLogConfig(container.server()).apply();

--- a/backend/api/src/main/java/com/anibalxyz/server/api/InfrastructureErrorMapper.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/api/InfrastructureErrorMapper.java
@@ -67,7 +67,8 @@ public class InfrastructureErrorMapper {
       @Override
       public ErrorResult execute(Exception e) {
         if (!(e instanceof EndpointNotFound)) return new ErrorResult(404, null);
-        return new ErrorResult(404, new ErrorResponse(CommonErrorCode.RESOURCE_NOT_FOUND).detail(e.getMessage()));
+        return new ErrorResult(
+            404, new ErrorResponse(CommonErrorCode.RESOURCE_NOT_FOUND).detail(e.getMessage()));
       }
     }
   }

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
@@ -27,7 +27,7 @@ public record AppEnvironmentSource(
     String SERVER_URL,
     String API_URL,
     int API_PORT,
-    String API_PREFIX,
+    String API_PUBLIC_URL,
     String[] CORS_ALLOWED_ORIGINS,
     String CONTACT_EMAIL,
     int BCRYPT_LOG_ROUNDS,

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/AppEnvironmentSource.java
@@ -38,7 +38,8 @@ public record AppEnvironmentSource(
     Boolean AUTH_COOKIE_SECURE,
     String AUTH_COOKIE_DOMAIN,
     SameSite AUTH_COOKIE_SAMESITE,
-    String AUTH_COOKIE_PATH)
+    String AUTH_COOKIE_PATH,
+    Boolean SWAGGER_ENABLED)
     implements UsersEnvironment,
         ServerEnvironment,
         JwtEnvironment,

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/ApplicationConfiguration.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/ApplicationConfiguration.java
@@ -13,7 +13,6 @@ public record ApplicationConfiguration(AppEnvironmentSource env, DatabaseVariabl
     Map<String, Object> api = new LinkedHashMap<>();
     api.put("url", env.API_URL());
     api.put("port", env.API_PORT());
-    api.put("prefix", env.API_PREFIX());
     api.put("corsOrigins", env.CORS_ALLOWED_ORIGINS());
     configSummary.put("api", api);
 

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
@@ -188,6 +188,12 @@ public class ConfigurationFactory {
       throw new IllegalStateException("Invalid value for AUTH_COOKIE_SAMESITE: " + e.getMessage());
     }
 
+    // Feature Flags
+    // TODO: add separate inner record for feature flags
+    String swaggerEnabledRaw = getEnvVar("SWAGGER_ENABLED", callback, true);
+    if (swaggerEnabledRaw == null || swaggerEnabledRaw.isBlank()) swaggerEnabledRaw = "false";
+    Boolean swaggerEnabled = Boolean.parseBoolean(swaggerEnabledRaw);
+
     AppEnvironmentSource env =
         new AppEnvironmentSource(
             appEnv,
@@ -207,7 +213,8 @@ public class ConfigurationFactory {
             authCookieSecure,
             authCookieDomain.isBlank() ? null : authCookieDomain,
             authCookieSameSite,
-            authCookiePath);
+            authCookiePath,
+            swaggerEnabled);
 
     ApplicationConfiguration result =
         new ApplicationConfiguration(

--- a/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/environment/ConfigurationFactory.java
@@ -127,9 +127,14 @@ public class ConfigurationFactory {
     }
     String apiHost = getEnvVar("API_HOST", callback);
     int apiPort = Integer.parseInt(getEnvVar("API_PORT", callback));
-    String apiPrefix = getEnvVar("API_PREFIX", callback);
+    String apiPrefix = "/api";
     String serverUrl = apiProtocol + "://" + apiHost + ":" + apiPort;
     String apiUrl = serverUrl + apiPrefix;
+    String apiPublicUrl = getEnvVar("API_PUBLIC_URL", callback, true);
+    if (apiPublicUrl == null || apiPublicUrl.isBlank()) {
+      apiPublicUrl = apiUrl;
+    }
+
     String frontendProtocol =
         Optional.ofNullable(getEnvVar("FRONTEND_PROTOCOL", callback, true))
             .filter(s -> !s.isBlank())
@@ -191,7 +196,7 @@ public class ConfigurationFactory {
             serverUrl,
             apiUrl,
             apiPort,
-            apiPrefix,
+            apiPublicUrl,
             corsAllowedOrigins,
             contactEmail,
             bcryptLogRounds,

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/ExceptionsConfig.java
@@ -1,5 +1,7 @@
 package com.anibalxyz.server.config.modules.runtime;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.anibalxyz.features.common.application.exception.FailureSignal;
 import com.anibalxyz.server.api.ErrorMapper;
 import com.anibalxyz.server.api.ErrorResult;
@@ -14,8 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;
-
-import static net.logstash.logback.argument.StructuredArguments.kv;
 
 // TODO: use a more semantic name for this class
 public class ExceptionsConfig extends RuntimeConfig {
@@ -63,9 +63,17 @@ public class ExceptionsConfig extends RuntimeConfig {
     emitLogEntry(result);
 
     if (result.status() >= 500) {
-      log.error("{}: {}", e.getClass().getSimpleName(), e.getMessage(), kv("error_code", result.response().code()));
+      log.error(
+          "{}: {}",
+          e.getClass().getSimpleName(),
+          e.getMessage(),
+          kv("error_code", result.response().code()));
     } else {
-      log.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage(), kv("error_code", result.response().code()));
+      log.debug(
+          "{}: {}",
+          e.getClass().getSimpleName(),
+          e.getMessage(),
+          kv("error_code", result.response().code()));
     }
 
     ctx.status(result.status()).json(result.response().instance(requestId));

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/MetricsConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/runtime/MetricsConfig.java
@@ -40,8 +40,7 @@ public class MetricsConfig extends RuntimeConfig {
 
     server.before(
         ctx -> {
-          if (ctx.path().equals(METRICS_PATH)
-              || ctx.path().startsWith("/webjars/")) return;
+          if (ctx.path().equals(METRICS_PATH) || ctx.path().startsWith("/webjars/")) return;
           ctx.attribute(METRICS_TIMER_ATTR, Timer.start(registry));
         });
 

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/ServerEnvironment.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/ServerEnvironment.java
@@ -9,9 +9,9 @@ public interface ServerEnvironment {
 
   String SERVER_URL();
 
-  String API_PREFIX();
-
   String[] CORS_ALLOWED_ORIGINS();
 
   String CONTACT_EMAIL();
+
+  String API_PUBLIC_URL();
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/SwaggerConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/SwaggerConfig.java
@@ -4,6 +4,7 @@ import com.anibalxyz.server.config.AppEnv;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.javalin.config.JavalinConfig;
+import io.javalin.openapi.plugin.DefinitionConfiguration;
 import io.javalin.openapi.plugin.OpenApiPlugin;
 import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
 
@@ -25,104 +26,95 @@ public class SwaggerConfig extends StartupConfig {
 
   @Override
   public void apply() {
-    String infoDescription =
-"""
-Financial transaction reconciliation API for teams to reconcile transactions between bank statements and internal
-systems. Built with clean architecture principles, domain-driven design, and comprehensive testing strategies.
-""";
+    registerOpenApiPlugin();
+    registerSwaggerPlugin();
+  }
+
+  public void registerSwaggerPlugin() {
+    javalinConfig.registerPlugin(
+        new SwaggerPlugin(
+            swaggerConfig -> {
+              swaggerConfig.setUiPath("/swagger");
+            }));
+  }
+
+  private void registerOpenApiPlugin() {
     javalinConfig.registerPlugin(
         new OpenApiPlugin(
             openApiConfig ->
                 openApiConfig
                     .withDocumentationPath("/openapi")
-                    .withDefinitionConfiguration(
-                        (version, definition) ->
-                            definition
-                                .withInfo(
-                                    info ->
-                                        info.title("Reconciler API")
-                                            .version("0.2.0") // TODO: use env var
-                                            .description(infoDescription)
-                                            // .termsOfService
-                                            // ("https://github.com/anibalxyz/reconciler/blob/main/README.md")
-                                            .contact(
-                                                "Anibal Boggio",
-                                                "https://github.com/anibalxyz",
-                                                env.CONTACT_EMAIL())
-                                            .license(
-                                                "MIT License",
-                                                "https://github.com/anibalxyz/reconciler/blob/main/LICENSE",
-                                                "MIT"))
-                                .withServer(
-                                    server ->
-                                        server
-                                            .description(
-                                                "API URL: add '" + env.API_PREFIX() + "' prefix")
-                                            .url(env.API_URL()))
-                                .withServer(
-                                    server -> server.description("Root URL").url(env.SERVER_URL()))
-                                .withSecurity(
-                                    openApiSecurity -> openApiSecurity.withBearerAuth("bearerAuth"))
-                                .withDefinitionProcessor(
-                                    content -> {
-                                      ObjectNode externalDocs = content.objectNode();
-                                      externalDocs.set(
-                                          "description",
-                                          new TextNode("Project Repository and Documentation"));
-                                      externalDocs.set(
-                                          "url",
-                                          new TextNode("https://github.com/anibalxyz/reconciler"));
-                                      content.set("externalDocs", externalDocs);
+                    .withDefinitionConfiguration(this::definitionConfiguration)));
+  }
 
-                                      // Add global tags for the API organization
-                                      var tagsArray = content.arrayNode();
+  private void definitionConfiguration(String version, DefinitionConfiguration definition) {
+    String infoDescription =
+"""
+Financial transaction reconciliation API for teams to reconcile transactions between bank statements and internal
+systems. Built with clean architecture principles, domain-driven design, and comprehensive testing strategies.
+""";
+    definition
+        .withInfo(
+            info ->
+                info.title("Reconciler API")
+                    .version("0.2.0") // TODO: use env var
+                    .description(infoDescription)
+                    // .termsOfService
+                    // ("https://github.com/anibalxyz/reconciler/blob/main/README.md")
+                    .contact("Anibal Boggio", "https://github.com/anibalxyz", env.CONTACT_EMAIL())
+                    .license(
+                        "MIT License",
+                        "https://github.com/anibalxyz/reconciler/blob/main/LICENSE",
+                        "MIT"))
+        .withSecurity(openApiSecurity -> openApiSecurity.withBearerAuth("bearerAuth"))
+        .withDefinitionProcessor(this::definitionProcessor);
+    setServers(definition);
+  }
 
-                                      var usersTag = content.objectNode();
-                                      usersTag.set("name", new TextNode("Users"));
-                                      usersTag.set(
-                                          "description",
-                                          new TextNode(
-                                              """
-                                              User management operations including CRUD functionality,
-                                              authentication, and authorization features.
-                                              """
-                                                  .trim()));
-                                      tagsArray.add(usersTag);
-
-                                      var authTag = content.objectNode();
-                                      authTag.set("name", new TextNode("Authentication"));
-                                      authTag.set(
-                                          "description",
-                                          new TextNode(
-                                              """
-                                              Endpoints for user authentication, including login and logout.
-                                              """
-                                                  .trim()));
-                                      tagsArray.add(authTag);
-
-                                      var systemTag = content.objectNode();
-                                      systemTag.set("name", new TextNode("System"));
-                                      systemTag.set(
-                                          "description",
-                                          new TextNode(
-                                              """
-                                              System-level operations, such as health checks and status monitoring.
-                                              """
-                                                  .trim()));
-                                      tagsArray.add(systemTag);
-
-                                      content.set("tags", tagsArray);
-
-                                      return content.toPrettyString();
-                                    }))));
-
-    // TODO: Maybe allow in production but with authorization
-    if (env.APP_ENV() == AppEnv.DEV) {
-      javalinConfig.registerPlugin(
-          new SwaggerPlugin(
-              swaggerConfig -> {
-                swaggerConfig.setUiPath("/swagger");
-              }));
+  private void setServers(DefinitionConfiguration definition) {
+    if (env.APP_ENV() == AppEnv.PROD) {
+      definition.withServer(
+          server -> server.description("Production Server").url(env.API_PUBLIC_URL()));
+    } else {
+      definition
+          .withServer(server -> server.description("API URL: add '/api' prefix").url(env.API_URL()))
+          .withServer(server -> server.description("Root URL").url(env.SERVER_URL()));
     }
+  }
+
+  private String definitionProcessor(ObjectNode content) {
+    ObjectNode externalDocs = content.objectNode();
+    externalDocs.set("description", new TextNode("Project Repository and Documentation"));
+    externalDocs.set("url", new TextNode("https://github.com/anibalxyz/reconciler"));
+    content.set("externalDocs", externalDocs);
+
+    // Add global tags for the API organization
+    var tagsArray = content.arrayNode();
+
+    var usersTag = content.objectNode();
+    usersTag.set("name", new TextNode("Users"));
+    usersTag.set(
+        "description",
+        new TextNode(
+            "User management operations including CRUD functionality, authentication, and authorization features."));
+    tagsArray.add(usersTag);
+
+    var authTag = content.objectNode();
+    authTag.set("name", new TextNode("Authentication"));
+    authTag.set(
+        "description",
+        new TextNode("Endpoints for user authentication, including login and logout."));
+    tagsArray.add(authTag);
+
+    var systemTag = content.objectNode();
+    systemTag.set("name", new TextNode("System"));
+    systemTag.set(
+        "description",
+        new TextNode("System-level operations, such as health checks and status monitoring."));
+    tagsArray.add(systemTag);
+
+    content.set("tags", tagsArray);
+
+    return content.toPrettyString();
   }
 }

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/SwaggerConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/SwaggerConfig.java
@@ -4,6 +4,7 @@ import com.anibalxyz.server.config.AppEnv;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.javalin.config.JavalinConfig;
+import io.javalin.http.Context;
 import io.javalin.openapi.plugin.DefinitionConfiguration;
 import io.javalin.openapi.plugin.OpenApiPlugin;
 import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
@@ -22,6 +23,27 @@ public class SwaggerConfig extends StartupConfig {
   public SwaggerConfig(JavalinConfig javalinConfig, ServerEnvironment env) {
     super(javalinConfig);
     this.env = env;
+  }
+
+  public static void swaggerPatch(Context ctx) {
+    String html = ctx.result();
+    if (html == null) return;
+    String patch =
+"""
+<script>
+  (function() {
+    const originalFetch = window.fetch;
+    window.fetch = function(...args) {
+      const options = args[1] || {};
+      options.credentials = 'same-origin';
+      args[1] = options;
+      return originalFetch.apply(this, args);
+    };
+    console.info("Swagger patched Successfully via 'after' handler");
+  })();
+</script>
+""";
+    ctx.result(html.replace("</body>", patch + "</body>"));
   }
 
   @Override

--- a/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/SwaggerConfig.java
+++ b/backend/api/src/main/java/com/anibalxyz/server/config/modules/startup/SwaggerConfig.java
@@ -25,9 +25,10 @@ public class SwaggerConfig extends StartupConfig {
     this.env = env;
   }
 
-  public static void swaggerPatch(Context ctx) {
+  public static void swaggerPatch(Context ctx, AppEnv env) {
     String html = ctx.result();
     if (html == null) return;
+    String credentialsOption = env == AppEnv.PROD ? "same-origin" : "include";
     String patch =
 """
 <script>
@@ -35,14 +36,15 @@ public class SwaggerConfig extends StartupConfig {
     const originalFetch = window.fetch;
     window.fetch = function(...args) {
       const options = args[1] || {};
-      options.credentials = 'same-origin';
+      options.credentials = '%s';
       args[1] = options;
       return originalFetch.apply(this, args);
     };
     console.info("Swagger patched Successfully via 'after' handler");
   })();
 </script>
-""";
+"""
+            .formatted(credentialsOption);
     ctx.result(html.replace("</body>", patch + "</body>"));
   }
 
@@ -99,8 +101,23 @@ systems. Built with clean architecture principles, domain-driven design, and com
           server -> server.description("Production Server").url(env.API_PUBLIC_URL()));
     } else {
       definition
-          .withServer(server -> server.description("API URL: add '/api' prefix").url(env.API_URL()))
-          .withServer(server -> server.description("Root URL").url(env.SERVER_URL()));
+          .withServer(
+              server ->
+                  server
+                      .description("API PREFIX only - proxied by frontend (the most comfortable)")
+                      .url("/api"))
+          .withServer(
+              server ->
+                  server
+                      .description(
+                          "API URL - direct-to-backend url but needs proper CORS configuration (/health does not work)")
+                      .url(env.API_URL()))
+          .withServer(
+              server ->
+                  server
+                      .description(
+                          "ROOT URL - currently used to complement API URL server (enables /health but blocks the rest)")
+                      .url(env.SERVER_URL()));
     }
   }
 

--- a/cli/src/reconciler_cli/modules/image.py
+++ b/cli/src/reconciler_cli/modules/image.py
@@ -17,8 +17,9 @@ core_buildable_services: List[str] = [
 ]
 
 BUILDABLE_SERVICES: Dict[str, List[str]] = {
-    "dev": core_buildable_services,
-    "prod": core_buildable_services + [SERVICES["NGINX"]],
+    "dev": core_buildable_services + [SERVICES["PROMETHEUS"]],
+    "prod": core_buildable_services
+    + [SERVICES["NGINX"], SERVICES["CERTBOT"], SERVICES["PROMETHEUS"]],
     "test": [SERVICES["API"]],
 }
 
@@ -29,6 +30,9 @@ REGISTRY_SERVICES = [
     SERVICES["NGINX"],
     SERVICES["DASHBOARD"],
     SERVICES["PUBLIC_SITE"],
+    SERVICES["FRONTEND"],
+    SERVICES["PROMETHEUS"],
+    SERVICES["CERTBOT"],
 ]
 
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -21,7 +21,6 @@ services:
       # Override when running in the same Docker network
       - PUBLIC_SITE_HOST=public-site
       - API_URL=http://api:${API_PORT}
-      - API_PREFIX=${API_PREFIX}
     ports:
       - "${DASHBOARD_PORT}:${DASHBOARD_PORT}"
     volumes:
@@ -53,7 +52,6 @@ services:
       # Override when running in the same Docker network
       - DASHBOARD_HOST=dashboard
       - API_URL=http://api:${API_PORT}
-      - API_PREFIX=${API_PREFIX}
     ports:
       - "${PUBLIC_SITE_PORT}:${PUBLIC_SITE_PORT}"
     volumes:

--- a/compose.monitoring.dev.yaml
+++ b/compose.monitoring.dev.yaml
@@ -1,5 +1,6 @@
 services:
   prometheus:
+    pull_policy: missing
     ports:
       - 9090:9090
 

--- a/compose.monitoring.yaml
+++ b/compose.monitoring.yaml
@@ -2,7 +2,7 @@ services:
   promtail:
     image: grafana/promtail:3.4.2
     container_name: reconciler-${APP_ENV}-promtail
-    pull_policy: always
+    pull_policy: missing
     command:
       - -config.file=/etc/promtail/promtail-config.yaml
       - -config.expand-env=true
@@ -20,7 +20,7 @@ services:
   loki:
     image: grafana/loki:3.4.2
     container_name: reconciler-${APP_ENV}-loki
-    pull_policy: always
+    pull_policy: missing
     command: -config.file=/etc/loki/loki-config.yaml
     volumes:
       - ./monitoring/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
@@ -29,7 +29,7 @@ services:
       - main
 
   prometheus:
-    image: anibalxyz/reconciler-prod-prometheus:latest
+    image: anibalxyz/reconciler-${APP_ENV}-prometheus:latest
     container_name: reconciler-${APP_ENV}-prometheus
     pull_policy: always
     environment:
@@ -43,13 +43,12 @@ services:
   grafana:
     image: grafana/grafana:11.6.0
     container_name: reconciler-${APP_ENV}-grafana
-    pull_policy: always
+    pull_policy: missing
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
-      # TODO: solve alert when running in dev: DOMAIN not set
-      - GF_SERVER_ROOT_URL=https://${DOMAIN}/grafana/
+      - GF_SERVER_ROOT_URL=https://${DOMAIN:-localhost}/grafana/
       - GF_INSTALL_PLUGINS=
     volumes:
       - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -4,6 +4,7 @@ services:
     environment:
       # Not used yet
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS},${DOMAIN}
+      - API_PUBLIC_URL=${FRONTEND_PROTOCOL}://${DOMAIN}/api
   db:
     ports: !reset []
   nginx:
@@ -15,7 +16,6 @@ services:
       - DOMAIN=${DOMAIN}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
       - API_PORT=${API_PORT}
-      - API_PREFIX=${API_PREFIX}
       - LIMIT_REQ_RATE=${LIMIT_REQ_RATE}
       - LIMIT_REQ_BURST=${LIMIT_REQ_BURST}
       # Used when running in the same Docker network. Change it in real production

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,6 +38,7 @@ services:
   flyway:
     image: flyway/flyway:11-alpine
     container_name: reconciler-${APP_ENV}-flyway
+    pull_policy: missing
     volumes:
       - ./backend/db/migrations:/flyway/sql
     command:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ const API_URL = env.API_URL ?? 'http://localhost:4001';
 
 console.log('API_URL: ', API_URL);
 
-const redirectApiDocsPlugin = (): Plugin => ({
+const redirectsPlugin = (): Plugin => ({
   name: 'redirect-api-docs',
   configureServer(server) {
     server.middlewares.use((req, res, next) => {
@@ -23,46 +23,9 @@ const redirectApiDocsPlugin = (): Plugin => ({
         redirect('/openapi');
         return;
       }
-      next();
-    });
-  },
-});
-
-// Note: this aims to be just a temporal patch, until the use of npm swagger-ui
-//       Generated with Claude
-const swaggerPatchPlugin = (): Plugin => ({
-  name: 'swagger-credentials-patch',
-  configureServer(server) {
-    server.middlewares.use(async (req, res, next) => {
-      if (req.url === '/swagger') {
-        try {
-          const backendUrl = `${API_URL}/swagger`;
-          const response = await fetch(backendUrl);
-          let html = await response.text();
-
-          html = html.replace(
-            '</body>',
-            `<script>
-              (function() {
-                const originalFetch = window.fetch;
-                window.fetch = function(...args) {
-                  const options = args[1] || {};
-                  options.credentials = 'include';
-                  args[1] = options;
-                  return originalFetch.apply(this, args);
-                };
-                console.log('✅ Swagger patched via Vite');
-              })();
-            </script>
-            </body>`,
-          );
-
-          res.setHeader('Content-Type', 'text/html; charset=utf-8');
-          res.end(html);
-          return;
-        } catch (error) {
-          console.error('Error proxying /swagger:', error);
-        }
+      if (req.url?.startsWith('/api/webjars')) {
+        redirect(req.url.replace('/api/webjars', '/webjars'));
+        return;
       }
       next();
     });
@@ -70,14 +33,20 @@ const swaggerPatchPlugin = (): Plugin => ({
 });
 
 export default defineConfig({
-  plugins: [tailwindcss(), redirectApiDocsPlugin(), swaggerPatchPlugin()],
+  plugins: [tailwindcss(), redirectsPlugin()],
   server: {
     proxy: {
+      '^/api/health$': {
+        target: API_URL,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
       '^/api($|/.*)': {
         target: API_URL,
         changeOrigin: true,
       },
-      '^/openapi$': {
+
+      '^/(openapi|swagger)$': {
         target: API_URL,
         changeOrigin: true,
       },

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -115,7 +115,19 @@ http {
       proxy_set_header Connection "";
     }
 
-    location ~ ^/(swagger|openapi)$ {
+    location = /api/health {
+      limit_req zone=api burst=${LIMIT_REQ_BURST} nodelay;
+      set $backend "${API_HOST}:${API_PORT}";
+      
+      proxy_pass http://$backend/health; 
+      
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header Connection "";
+    }
+
+    location ~ ^/(swagger|openapi|webjars) {
       set $backend "${API_HOST}:${API_PORT}";
       proxy_pass http://$backend;
       proxy_http_version 1.1;
@@ -124,12 +136,9 @@ http {
       proxy_set_header Connection "";
     }
 
-    location = /api/openapi {
-      return 301 /openapi;
+    location ~ ^/api/(openapi|swagger|webjars/.+) {
+        return 301 /$1;
     }
-
-    # NOTE: in the future SwaggerUI will be accessible in production.
-    #       That requires: accept /webjars/* | /openapi* ; accept /swagger as with /openapi
 
     location ~ ^/dashboard/assets/ {
       root /usr/share/nginx/html;


### PR DESCRIPTION
## What

1. **Swagger made production-ready**: `SWAGGER_ENABLED` feature flag controls availability per environment. Cookie credentials are now environment-aware (same-origin in prod, include in dev). The Vite swagger patch is removed and the backend handles it now.
2. **`API_PREFIX` removed**: hardcoded to `/api` internally. `API_PUBLIC_URL` replaces it for the Swagger server URL in production.
3. **Nginx and Vite proxy improvements**: `/api/health`, `/api/webjars`, `/api/swagger`, and `/api/openapi` routes unified and corrected across both Nginx and Vite.
4. **Monitoring stack fixes**: `pull_policy: missing` for Grafana/Loki/Promtail (avoid unnecessary pulls), Grafana `DOMAIN` fallback to `localhost` for dev, Prometheus image tag made environment-aware.

## Why

**Swagger**: The previous setup had the cookie credentials patch only in Vite (`swaggerPatchPlugin`), available only in dev. Now it's moved to the backend and available in all environments. The patch itself is identical, but credentials switch to `same-origin` in prod and `include` in dev. Swagger was enabled by checking `APP_ENV == DEV` inline. `API_PREFIX` was an env var that was always `/api` anyway.

**Nginx/Vite**: `/api/health` wasn't proxied correctly (it was being caught by the generic `/api/` rule and forwarded with the `/api` prefix intact, causing 404s). `/webjars` assets for Swagger UI weren't reachable via the `/api/webjars` path. The old `/api/openapi` redirect was a 301 that didn't cover swagger or webjars.

**Monitoring**: `pull_policy: always` on Grafana/Loki/Promtail caused unnecessary registry pulls on every `compose up`. Grafana failed in dev because `DOMAIN` was unset.

## How

### Swagger

- **`SWAGGER_ENABLED`**: new boolean env var. Defaults to `true` in dev, `false` in prod and test. Guards both `SwaggerConfig` registration and the redirect routes (`/` -> `/swagger`).
- **`API_PUBLIC_URL`**: new env var replacing `API_PREFIX`. In prod, injected as `${FRONTEND_PROTOCOL}://${DOMAIN}/api` via `compose.prod.yaml`. Falls back to `API_URL` if unset. Used as the single server URL in the prod OpenAPI spec.
- **`swaggerPatch`**: moved entirely to the backend as a static method on `SwaggerConfig`, called via Javalin's `after("/swagger")` handler. Credentials set to `same-origin` in prod, `include` in dev.
- **`SwaggerConfig`**: refactored from one large `apply()` into `registerOpenApiPlugin()`, `registerSwaggerPlugin()`, `definitionConfiguration()`, `setServers()`, and `definitionProcessor()`.
- **Vite**: `swaggerPatchPlugin` removed. `redirectApiDocsPlugin` renamed to `redirectsPlugin` and extended with `/api/webjars` -> `/webjars` redirect. Proxy extended to cover `/swagger` and adds a dedicated rule for `/api/health` with path rewrite.

### Nginx

- Added `location = /api/health` with explicit `proxy_pass http://$backend/health` (strips the `/api` prefix correctly).
- Extended `location ~ ^/(swagger|openapi|webjars)` to include webjars assets.
- Added `location ~ ^/api/(openapi|swagger|webjars/.+)` with 301 redirect to `/$1` to normalize `/api/*` doc paths.
- Removed the old `location = /api/openapi` redirect.

### Monitoring

- `pull_policy: missing` for Grafana, Loki, Promtail (`always` is needed only in custom Docker images).
- Prometheus image: `anibalxyz/reconciler-${APP_ENV}-prometheus:latest` (was hardcoded to `prod`).
- Grafana: `GF_SERVER_ROOT_URL` uses `${DOMAIN:-localhost}` fallback to avoid Compose alerts when running dev.
- CLI: Prometheus and Certbot added to `BUILDABLE_SERVICES` and `REGISTRY_SERVICES`.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Edge cases considered