### PR TITLE
chore: update backend dependencies

### DIFF
--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -13,25 +13,25 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jetbrains.annotations.version>26.0.2</jetbrains.annotations.version>
-        <postgresql.version>42.7.8</postgresql.version>
+        <jetbrains.annotations.version>26.1.0</jetbrains.annotations.version>
+        <postgresql.version>42.7.11</postgresql.version>
         <jackson.version>2.21.3</jackson.version>
         <javalin.version>6.7.0</javalin.version>
         <jakarta-persistence.version>3.2.0</jakarta-persistence.version>
         <hibernate.version>7.1.0.Final</hibernate.version>
         <jbcrypt.version>0.4</jbcrypt.version>
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.32</logback.version>
-        <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version>
+        <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version> <!-- 9.0 -->
         <micrometer-registry-prometheus.version>1.16.5</micrometer-registry-prometheus.version>
         <janino.version>3.1.12</janino.version>
-        <junit.version>5.13.4</junit.version>
-        <mockito.version>5.19.0</mockito.version>
+        <junit.version>5.14.4</junit.version> <!-- 6.1.0 -->
+        <mockito.version>5.23.0</mockito.version>
         <assertj.version>3.27.7</assertj.version>
-        <okhttp.version>4.12.0</okhttp.version>
+        <okhttp.version>4.12.0</okhttp.version> <!-- 5.3.2 -->
 
-        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <jjwt.version>0.13.0</jjwt.version>
     </properties>
 
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -25,7 +25,7 @@
         <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version> <!-- 9.0 -->
         <micrometer-registry-prometheus.version>1.16.5</micrometer-registry-prometheus.version>
         <janino.version>3.1.12</janino.version>
-        <junit.version>5.14.4</junit.version> <!-- 6.1.0 -->
+        <junit.version>6.1.0</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <assertj.version>3.27.7</assertj.version>
         <okhttp.version>4.12.0</okhttp.version> <!-- 5.3.2 -->

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -28,7 +28,7 @@
         <junit.version>6.1.0</junit.version>
         <mockito.version>5.23.0</mockito.version>
         <assertj.version>3.27.7</assertj.version>
-        <okhttp.version>4.12.0</okhttp.version> <!-- 5.3.2 -->
+        <okhttp.version>5.3.2</okhttp.version>
 
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
@@ -303,7 +303,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
             <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -15,14 +15,14 @@
 
         <jetbrains.annotations.version>26.1.0</jetbrains.annotations.version>
         <postgresql.version>42.7.11</postgresql.version>
-        <jackson.version>2.21.3</jackson.version>
+        <jackson.version>3.1.3</jackson.version>
         <javalin.version>6.7.0</javalin.version>
         <jakarta-persistence.version>3.2.0</jakarta-persistence.version>
         <hibernate.version>7.4.0.Final</hibernate.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.32</logback.version>
-        <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version> <!-- 9.0 -->
+        <logstash-logback-encoder.version>9.0</logstash-logback-encoder.version>
         <micrometer-registry-prometheus.version>1.16.5</micrometer-registry-prometheus.version>
         <janino.version>3.1.12</janino.version>
         <junit.version>6.1.0</junit.version>
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <annotationProcessorPath>
@@ -157,15 +157,16 @@
         <!-- JSON Mapper -->
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 
+        <!-- TODO: remove to 'tools.jackson' once Javalin updated to v7 -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
+            <version>2.21.3</version>
         </dependency>
 
         <!-- Web Framework -->
@@ -322,7 +323,7 @@
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
+            <artifactId>jjwt-gson</artifactId>
             <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/backend/api/pom.xml
+++ b/backend/api/pom.xml
@@ -18,7 +18,7 @@
         <jackson.version>2.21.3</jackson.version>
         <javalin.version>6.7.0</javalin.version>
         <jakarta-persistence.version>3.2.0</jakarta-persistence.version>
-        <hibernate.version>7.1.0.Final</hibernate.version>
+        <hibernate.version>7.4.0.Final</hibernate.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.32</logback.version>

--- a/backend/api/src/test/java/com/anibalxyz/features/auth/AuthRoutesIntegrationTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/auth/AuthRoutesIntegrationTest.java
@@ -30,9 +30,6 @@ import com.anibalxyz.server.config.environment.AppEnvironmentSource;
 import com.anibalxyz.shared.Constants;
 import com.anibalxyz.shared.HttpRequest;
 import com.anibalxyz.shared.MutableClock;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.javalin.http.UnauthorizedResponse;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -44,6 +41,7 @@ import java.util.function.Consumer;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.junit.jupiter.api.*;
+import tools.jackson.databind.ObjectMapper;
 
 @DisplayName("Tests for AuthRoutes")
 public class AuthRoutesIntegrationTest {
@@ -73,9 +71,7 @@ public class AuthRoutesIntegrationTest {
     String baseUrl = app.javalin().jettyServer().server().getURI().toString() + "api";
     emf = app.persistenceManager().emf();
     ObjectMapper objectMapper =
-        new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        new ObjectMapper();
 
     http = new HttpRequest(objectMapper, new OkHttpClient(), baseUrl);
 

--- a/backend/api/src/test/java/com/anibalxyz/features/auth/JwtMiddlewareIntegrationTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/auth/JwtMiddlewareIntegrationTest.java
@@ -20,9 +20,6 @@ import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.InfrastructureErrorMapper;
 import com.anibalxyz.shared.Constants;
 import com.anibalxyz.shared.HttpRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.javalin.http.UnauthorizedResponse;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -40,6 +37,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import tools.jackson.databind.ObjectMapper;
 
 @DisplayName("Tests for JwtMiddleware")
 public class JwtMiddlewareIntegrationTest {
@@ -59,10 +57,7 @@ public class JwtMiddlewareIntegrationTest {
 
     String baseUrl = app.javalin().jettyServer().server().getURI().toString() + "api";
     emf = app.persistenceManager().emf();
-    ObjectMapper objectMapper =
-        new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    ObjectMapper objectMapper = new ObjectMapper();
 
     http = new HttpRequest(objectMapper, new OkHttpClient(), baseUrl);
   }

--- a/backend/api/src/test/java/com/anibalxyz/features/users/UsersRoutesIntegrationTest.java
+++ b/backend/api/src/test/java/com/anibalxyz/features/users/UsersRoutesIntegrationTest.java
@@ -30,12 +30,9 @@ import com.anibalxyz.server.api.ErrorResult;
 import com.anibalxyz.server.api.InfrastructureErrorMapper;
 import com.anibalxyz.shared.Constants;
 import com.anibalxyz.shared.HttpRequest;
+// TODO: update to 'tools.jackson' once Javalin updated to v7
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.javalin.http.BadRequestResponse;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -50,12 +47,17 @@ import okhttp3.Response;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 @DisplayName("Tests for UserRoutes")
 public class UsersRoutesIntegrationTest {
   private static final ZonedDateTime FIXED_NOW =
       LocalDateTime.of(2025, 11, 25, 10, 0).atZone(ZoneId.of("America/Montevideo"));
   private static final Clock testClock = Clock.fixed(FIXED_NOW.toInstant(), FIXED_NOW.getZone());
+  private static final Logger log = LoggerFactory.getLogger(UsersRoutesIntegrationTest.class);
   private static HttpRequest http;
   private static Application app;
   private static EntityManagerFactory emf;
@@ -70,10 +72,7 @@ public class UsersRoutesIntegrationTest {
 
     String baseUrl = app.javalin().jettyServer().server().getURI().toString() + "api";
     emf = app.persistenceManager().emf();
-    ObjectMapper objectMapper =
-        new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    ObjectMapper objectMapper = new ObjectMapper();
 
     http = new HttpRequest(objectMapper, new OkHttpClient(), baseUrl);
   }

--- a/backend/api/src/test/java/com/anibalxyz/shared/HttpRequest.java
+++ b/backend/api/src/test/java/com/anibalxyz/shared/HttpRequest.java
@@ -2,12 +2,12 @@ package com.anibalxyz.shared;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
 import okhttp3.*;
 import org.jetbrains.annotations.NotNull;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Utility class for simplifying the process of sending HTTP requests and parsing responses,
@@ -43,13 +43,9 @@ public class HttpRequest {
   }
 
   private RequestBody createJsonRequestBody(Object body) {
-    try {
-      String jsonBody =
-          body.getClass().equals(String.class) ? (String) body : mapper.writeValueAsString(body);
-      return okhttp3.RequestBody.create(jsonBody, okhttp3.MediaType.get("application/json"));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    String jsonBody =
+        body.getClass().equals(String.class) ? (String) body : mapper.writeValueAsString(body);
+    return okhttp3.RequestBody.create(jsonBody, okhttp3.MediaType.get("application/json"));
   }
 
   public Response post(String path, @NotNull Object body) {


### PR DESCRIPTION
## What

Update backend dependencies: Jackson v3, Hibernate 7.4, Logstash Logback Encoder v9, OkHttp 5.x, JUnit 6.1, Mockito 5.23, SLF4J 2.0.18, plus minor bumps for PostgreSQL, JetBrains annotations, and Maven plugins.

## Why

The dependency tree had accumulated drift. A single pass now avoids cascading upgrade problems during feature development.

## How

Non-obvious details the diff shows but does not explain:

- **jjwt-jackson replaced with jjwt-gson**: jjwt-jackson depends on `com.fasterxml.jackson` (Jackson v2). Keeping it after the Jackson v3 migration would reintroduce Jackson v2 as a transitive dependency. jjwt-gson avoids that conflict.

- **JSR310 pinned at Jackson v2**: The TODO in `pom.xml` states the reason. Javalin 6.x serializes internally with Jackson v2. JSR310 stays on 2.21.3 until Javalin 7 ships with Jackson v3 support.

- **ObjectMapper no longer needs JavaTimeModule**: `tools.jackson.databind.ObjectMapper` handles `java.time` types natively. The `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS` opt-out is also unnecessary.

- **HttpRequest no longer catches IOException**: Jackson v3 `writeValueAsString` throws `JacksonException` (unchecked) instead of `IOException`. The try/catch wrapper no longer compiles.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Edge cases considered
- [ ] N/A (no tests required)

## Other information

**Namespace change**: `com.fasterxml.jackson` -> `tools.jackson` across all updated imports. Two remaining `com.fasterxml.jackson` imports in `UsersRoutesIntegrationTest` are for exception types used by Javalin 6.x internally. They stay until the Javalin 7 migration.
