### PR TITLE
fix: update astro v6.4

### DIFF
--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -2,7 +2,7 @@
 # ==> Application Configuration                  #
 # ---------------------------------------------- #
 
-API_PROTOCOL=https
+API_PROTOCOL=http
 API_HOST=localhost
 API_PORT=4002
 

--- a/frontend/.env.prod.example
+++ b/frontend/.env.prod.example
@@ -1,4 +1,4 @@
-FRONTEND_PROTOCOL=http # Defaults to https
+FRONTEND_PROTOCOL=https
 
 # Used when running locally. Overwritten if running with Docker.
 # This value must be changed manually if you modify the API socket in its dotenv file.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,26 +63,32 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
-      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.4"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
-      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/internal-helpers": "0.10.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -90,9 +96,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -3355,14 +3358,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.8.tgz",
-      "integrity": "sha512-xH2UA8Z17IS+JaqSlSkBor7jO6gd7zXTLdmu06nKpfpDDJFbi/7KZEy3NDmWxmier+6XrCZ9Z4aitO8jhC9oiA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.2.tgz",
+      "integrity": "sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@astrojs/internal-helpers": "0.9.1",
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -8888,7 +8891,7 @@
     "public-site": {
       "name": "@anibalxyz/reconciler-public-site",
       "dependencies": {
-        "astro": "6.3.8"
+        "astro": "6.4.2"
       },
       "devDependencies": {
         "eslint-plugin-astro": "1.7.0",

--- a/frontend/public-site/package.json
+++ b/frontend/public-site/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "astro": "6.3.8"
+    "astro": "6.4.2"
   },
   "devDependencies": {
     "eslint-plugin-astro": "1.7.0",


### PR DESCRIPTION
## Summary

Bump Astro from 6.3.8 to 6.4.2 to pick up a fix for a bug that casues the dev toolbar to dissapear on Vite dependency optimization.
The root cause is in Vite (vitejs/vite#22303, vitejs/vite#19323) but Astro addressed it for their use case in withastro/astro#16770, fixing withastro/astro#16766.

Align `.env.prod.example` defaults with production reality:

- `FRONTEND_PROTOCOL` defaults to `https` (prod always serves over HTTPS).
- `API_PROTOCOL` defaults to `http` (the API sits behind nginx SSL termination, no reason to expect direct HTTPS).

## Key decisions

- **Single PR for unrelated changes**: the dotenv files alignment was a pending cleanup with no urgency, folded into this short PR to leave things cleaner than found.
- Although are intended to be edited, I prefer to keep the default values as close as possible to the production reality. This way the project needs less configuration to be run.

## Testing

- [x] N/A (no tests required)